### PR TITLE
feat(npm): publish @atomic-mail packages to GitHub Packages on release.

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: publish-npm-${{ github.event.release.tag_name || inputs.version || github.run_id }}
@@ -55,3 +56,20 @@ jobs:
       - name: Publish to npm
         working-directory: ts
         run: deno run -A publish_all_npm.ts
+
+      - name: Build GitHub Packages variants
+        working-directory: ts
+        run: deno run -A build_github_packages_npm.ts "${{ steps.version.outputs.version }}"
+
+      - name: Setup Node.js for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: "@atomic-mail"
+
+      - name: Publish to GitHub Packages
+        working-directory: ts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: deno run -A publish_github_packages_npm.ts

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@atomic-mail:registry=https://npm.pkg.github.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,15 @@ cd ts && deno test --allow-read --allow-env --allow-write
 cd ts
 deno run -A build_mcp_npm.ts <version>    # -> ts/mcp_npm/
 deno run -A build_skill_npm.ts <version>  # -> ts/skill_npm/
+deno run -A build_all_npm.ts <version>    # default + all channel variants
+```
+
+GitHub Packages (`@atomic-mail/*` on `npm.pkg.github.com`):
+
+```bash
+cd ts
+deno run -A build_github_packages_npm.ts <version>  # -> ts/mcp_npm_gpr/, ts/skill_npm_gpr/
+deno run -A publish_github_packages_npm.ts          # publish built GPR dirs
 ```
 
 Omit `<version>` to use `ts/src/mcp/version.ts`. Manual QA checklists for

--- a/ts/build_github_packages_npm.ts
+++ b/ts/build_github_packages_npm.ts
@@ -1,0 +1,22 @@
+// Build GitHub Packages npm variants (@atomic-mail/* on npm.pkg.github.com).
+//
+// Usage:
+//   deno run -A build_github_packages_npm.ts <version>   # CI / release
+//   deno run -A build_github_packages_npm.ts             # local fallback from version.ts
+
+import { buildGithubPackagesNpm } from "./lib/build_npm.ts";
+import { parseReleaseVersion } from "./lib/version.ts";
+import { ATOMICMAIL_MCP_VERSION } from "./src/mcp/version.ts";
+
+const rawVersion = Deno.args[0];
+const version = rawVersion
+  ? parseReleaseVersion(rawVersion)
+  : ATOMICMAIL_MCP_VERSION;
+
+const dirs = await buildGithubPackagesNpm(version);
+for (const dir of dirs) {
+  const pkg = JSON.parse(await Deno.readTextFile(`${dir}/package.json`));
+  console.log(`Built ${pkg.name}@${version} -> ./${dir}`);
+}
+
+console.log(`Done: ${dirs.length} GitHub Packages at version ${version}.`);

--- a/ts/lib/build_npm.ts
+++ b/ts/lib/build_npm.ts
@@ -1,6 +1,9 @@
 import { build, emptyDir } from "@deno/dnt";
 
-import { ATOMICMAIL_NPM_PACKAGE_META } from "../npm_package_meta.ts";
+import {
+  ATOMICMAIL_GITHUB_PACKAGES_PUBLISH_CONFIG,
+  ATOMICMAIL_NPM_PACKAGE_META,
+} from "../npm_package_meta.ts";
 
 export type NpmProduct = "mcp" | "skill";
 
@@ -60,6 +63,17 @@ const PRODUCT_CONFIG = {
   },
 } as const;
 
+const GITHUB_PACKAGES = {
+  mcp: {
+    packageName: "@atomic-mail/mcp",
+    outDir: "mcp_npm_gpr",
+  },
+  skill: {
+    packageName: "@atomic-mail/agent-skill",
+    outDir: "skill_npm_gpr",
+  },
+} as const;
+
 export function loadChannels(): string[] {
   const text = Deno.readTextFileSync(
     new URL("../npm_channels.json", import.meta.url),
@@ -113,19 +127,30 @@ async function prependChannelReadme(
   await Deno.writeTextFile(readmePath, note + existing);
 }
 
+export interface BuildNpmPackageOverrides {
+  packageName?: string;
+  outDir?: string;
+  description?: string;
+  homepage?: string;
+  publishConfig?: typeof ATOMICMAIL_NPM_PACKAGE_META.publishConfig;
+  atomicmail?: { channel: string };
+}
+
 export interface BuildNpmPackageOptions {
   product: NpmProduct;
   version: string;
   channel?: string;
+  overrides?: BuildNpmPackageOverrides;
 }
 
 export async function buildNpmPackage(
   options: BuildNpmPackageOptions,
 ): Promise<string> {
-  const { product, version, channel } = options;
+  const { product, version, channel, overrides } = options;
   const config = PRODUCT_CONFIG[product];
-  const dir = getOutputDir(product, channel);
-  const packageName = getPackageName(product, channel);
+  const dir = overrides?.outDir ?? getOutputDir(product, channel);
+  const packageName = overrides?.packageName ??
+    getPackageName(product, channel);
 
   await emptyDir(dir);
 
@@ -151,12 +176,17 @@ export async function buildNpmPackage(
     package: {
       name: packageName,
       version,
-      description: channelDescription(config.description, channel),
+      description: overrides?.description ??
+        channelDescription(config.description, channel),
       license: "MIT",
       ...ATOMICMAIL_NPM_PACKAGE_META,
-      homepage: buildHomepage(channel),
+      ...(overrides?.publishConfig && {
+        publishConfig: overrides.publishConfig,
+      }),
+      homepage: overrides?.homepage ?? buildHomepage(channel),
       keywords: buildKeywords(config.keywords, channel),
-      atomicmail: channel ? { channel } : { channel: "default" },
+      atomicmail: overrides?.atomicmail ??
+        (channel ? { channel } : { channel: "default" }),
       engines: {
         node: ">=20",
       },
@@ -194,6 +224,33 @@ export async function buildNpmPackage(
   return dir;
 }
 
+export async function buildGithubPackagesNpm(
+  version: string,
+): Promise<string[]> {
+  const dirs: string[] = [];
+  for (const product of ["mcp", "skill"] as const) {
+    const gpr = GITHUB_PACKAGES[product];
+    const config = PRODUCT_CONFIG[product];
+    const dir = await buildNpmPackage({
+      product,
+      version,
+      overrides: {
+        packageName: gpr.packageName,
+        outDir: gpr.outDir,
+        description: config.description,
+        homepage: buildHomepage("github-packages"),
+        publishConfig: ATOMICMAIL_GITHUB_PACKAGES_PUBLISH_CONFIG,
+      },
+    });
+    dirs.push(dir);
+  }
+  return dirs;
+}
+
+export function listGithubPackagesDirs(): string[] {
+  return ["mcp_npm_gpr", "skill_npm_gpr"];
+}
+
 export interface ParsedBuildArgs {
   version?: string;
   channel?: string;
@@ -221,6 +278,7 @@ export function listBuiltPackageDirs(): string[] {
   const dirs: string[] = [];
   for (const entry of Deno.readDirSync(".")) {
     if (!entry.isDirectory) continue;
+    if (entry.name.endsWith("_npm_gpr")) continue;
     if (
       entry.name === "mcp_npm" ||
       entry.name === "skill_npm" ||

--- a/ts/npm_package_meta.ts
+++ b/ts/npm_package_meta.ts
@@ -13,3 +13,8 @@ export const ATOMICMAIL_NPM_PACKAGE_META = {
     access: "public" as const,
   },
 };
+
+export const ATOMICMAIL_GITHUB_PACKAGES_PUBLISH_CONFIG = {
+  registry: "https://npm.pkg.github.com",
+  access: "public" as const,
+} as const;

--- a/ts/publish_github_packages_npm.ts
+++ b/ts/publish_github_packages_npm.ts
@@ -1,0 +1,84 @@
+// Publish GitHub Packages npm variants from ts/*_npm_gpr output dirs.
+//
+// Usage:  deno run -A publish_github_packages_npm.ts
+//
+// Skips packages whose name@version already exists on GitHub Packages.
+
+import { listGithubPackagesDirs } from "./lib/build_npm.ts";
+
+const GPR_REGISTRY = "https://npm.pkg.github.com";
+
+interface PackageJson {
+  name: string;
+  version: string;
+}
+
+async function readPackageJson(dir: string): Promise<PackageJson> {
+  const text = await Deno.readTextFile(`${dir}/package.json`);
+  return JSON.parse(text) as PackageJson;
+}
+
+async function versionExistsOnRegistry(
+  name: string,
+  version: string,
+): Promise<boolean> {
+  const command = new Deno.Command("npm", {
+    args: [
+      "view",
+      `${name}@${version}`,
+      "version",
+      `--registry=${GPR_REGISTRY}`,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout } = await command.output();
+  if (code !== 0) return false;
+  return new TextDecoder().decode(stdout).trim() === version;
+}
+
+async function publishPackage(dir: string): Promise<"published" | "skipped"> {
+  const pkg = await readPackageJson(dir);
+  const label = `${pkg.name}@${pkg.version}`;
+
+  if (await versionExistsOnRegistry(pkg.name, pkg.version)) {
+    console.log(`Skip ${label} (already on GitHub Packages)`);
+    return "skipped";
+  }
+
+  console.log(`Publishing ${label} from ./${dir} ...`);
+  const command = new Deno.Command("npm", {
+    args: ["publish", "--access", "public"],
+    cwd: dir,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const { code } = await command.output();
+  if (code !== 0) {
+    throw new Error(`npm publish failed for ${label} (exit ${code})`);
+  }
+
+  console.log(`Published ${label}`);
+  return "published";
+}
+
+const dirs = listGithubPackagesDirs();
+if (dirs.length === 0) {
+  console.error(
+    "No GitHub Packages npm dirs configured. Run build_github_packages_npm.ts first.",
+  );
+  Deno.exit(1);
+}
+
+let published = 0;
+let skipped = 0;
+
+for (const dir of dirs) {
+  const result = await publishPackage(dir);
+  if (result === "published") published++;
+  else skipped++;
+}
+
+console.log(
+  `Done: ${published} published, ${skipped} skipped (${dirs.length} total).`,
+);


### PR DESCRIPTION
Wire GPR build and publish into the existing release workflow so MCP and agent-skill appear on the repository Packages sidebar alongside npmjs.