### PR TITLE
feat(clawhub): add MCP-only ClawHub publishing path

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -1,0 +1,74 @@
+name: Publish ClawHub package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semver to publish (e.g. 0.1.2 or v1.0.0)
+        required: true
+        type: string
+      dry_run:
+        description: Run ClawHub publish in dry-run mode
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-clawhub-${{ github.event.release.tag_name || inputs.version || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  verify-wrapper:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Resolve and validate version
+        id: version
+        working-directory: ts
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          VERSION=$(deno run -A resolve_release_version.ts "$RELEASE_TAG")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: $VERSION"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build OpenClaw wrapper package
+        working-directory: ts
+        run: deno run -A build_openclaw_wrapper.ts "${{ steps.version.outputs.version }}"
+
+      - name: Pack wrapper artifact
+        run: npm pack ./integrations_dist/openclaw/atomicmail
+
+      - name: Pack source wrapper
+        run: npm pack ./integrations/openclaw/atomicmail
+
+  publish:
+    needs: verify-wrapper
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
+    with:
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      source: ./integrations/openclaw/atomicmail
+      version: ${{ needs.verify-wrapper.outputs.version }}
+    secrets:
+      clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,13 @@ credentials.json
 *.jwt
 **/*.jwt
 
+# Generated integration artifacts and local package tarballs
+integrations_dist/
+/openclaw/
+/openclaw_dist/
+*.tgz
+**/*.tgz
+
 # Logs
 *.log
 **/*.log

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 **Not AI for your email. Email for your AI.**
 
-[Website](https://atomicmail.ai) · [Docs](docs/getting-started.md) · [Issues](https://github.com/Atomic-Mail/agentic-clients/issues) · [@atomicmail/mcp-github](https://www.npmjs.com/package/@atomicmail/mcp-github) · [@atomicmail/agent-skill-github](https://www.npmjs.com/package/@atomicmail/agent-skill-github)
+[Website](https://atomicmail.ai) · [Docs](docs/getting-started.md) · [Issues](https://github.com/Atomic-Mail/agentic-clients/issues) · [@atomicmail/mcp-github](https://www.npmjs.com/package/@atomicmail/mcp-github) · [@atomicmail/mcp-clawhub](https://www.npmjs.com/package/@atomicmail/mcp-clawhub)
 
 This repository ships the two client integrations for the Atomic Mail ESP:
 `@atomicmail/mcp-github` for MCP hosts and `@atomicmail/agent-skill-github` for shell agents.
+For ClawHub installs, use the MCP-only channel package
+`@atomicmail/mcp-clawhub`.
 Both wrap the same hosted Atomic Mail APIs with a tiny but powerful surface area: `register`,
 `jmap_request`, and `help`.
 
@@ -33,6 +35,19 @@ Add this to your MCP host config:
 ```
 
 Then restart the host and call: `register` → `jmap_request` → `help`.
+
+For ClawHub, install the MCP-only channel package instead:
+
+```json
+{
+  "mcpServers": {
+    "atomicmail": {
+      "command": "npx",
+      "args": ["-y", "@atomicmail/mcp-clawhub"]
+    }
+  }
+}
+```
 
 ### 💻 AgentSkill
 
@@ -86,6 +101,7 @@ That is the shortest path from zero to a working agent inbox.
 | Package                   | Best for                                                  | Surface                                            |
 | ------------------------- | --------------------------------------------------------- | -------------------------------------------------- |
 | `@atomicmail/mcp-github`         | Cursor, Claude Desktop, OpenClaw, Hermes, other MCP hosts | MCP server with `register`, `jmap_request`, `help` |
+| `@atomicmail/mcp-clawhub`        | ClawHub                                                  | MCP server with `register`, `jmap_request`, `help` |
 | `@atomicmail/agent-skill-github` | Shell agents, cron, CI, scripts                           | CLI with the same 3 commands                       |
 
 Shared presets bundled into both packages:
@@ -100,7 +116,7 @@ Shared presets bundled into both packages:
 
 ```text
 Agent host / shell
-  -> @atomicmail/mcp-github or @atomicmail/agent-skill-github
+  -> @atomicmail/mcp-github, @atomicmail/mcp-clawhub, or @atomicmail/agent-skill-github
   -> shared TypeScript runtime
   -> auth.atomicmail.ai (challenge -> session -> capability)
   -> api.atomicmail.ai (JMAP)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,19 @@ Add to your MCP host configuration:
 
 Then call tools in this order: `register` -> `jmap_request` -> `help`.
 
+For ClawHub, use the MCP-only channel package:
+
+```json
+{
+  "mcpServers": {
+    "atomicmail": {
+      "command": "npx",
+      "args": ["-y", "@atomicmail/mcp-clawhub"]
+    }
+  }
+}
+```
+
 Continue with full docs: [`MCP in-depth`](/mcp).
 
 ## Install for shell-capable agents (AgentSkill)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -41,6 +41,19 @@ preset shadowing. If anything disagrees with docs you read elsewhere, **trust
 
 Your MCP host spawns this process; see configuration below.
 
+For ClawHub, use the MCP-only channel package:
+
+```json
+{
+  "mcpServers": {
+    "atomicmail": {
+      "command": "npx",
+      "args": ["-y", "@atomicmail/mcp-clawhub"]
+    }
+  }
+}
+```
+
 ## Tools exposed
 
 | Tool           | Description                                                                                                                                                                                                       |

--- a/integrations/openclaw/atomicmail/LICENSE
+++ b/integrations/openclaw/atomicmail/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Atomic Mail
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integrations/openclaw/atomicmail/README.md
+++ b/integrations/openclaw/atomicmail/README.md
@@ -1,0 +1,71 @@
+# Atomic Mail for OpenClaw
+
+This package is a thin OpenClaw/ClawHub wrapper for the real Atomic Mail MCP
+runtime: `@atomicmail/mcp-clawhub`.
+
+## Intent
+
+ClawHub publishes plugin/package artifacts rather than raw MCP registry entries.
+This wrapper gives Atomic Mail a ClawHub-friendly package while leaving the
+actual MCP server implementation in the existing npm runtime package.
+
+## Setup
+
+ClawHub/OpenClaw package identity lives here:
+`@atomicmail/openclaw-atomicmail`.
+
+The real MCP server remains:
+`@atomicmail/mcp-clawhub`.
+
+Print the exact OpenClaw setup commands:
+
+```bash
+npx --package=@atomicmail/openclaw-atomicmail atomicmail-openclaw-mcp-config
+```
+
+Register the MCP server explicitly:
+
+```bash
+openclaw mcp add atomicmail --command npx --arg -y --arg @atomicmail/mcp-clawhub
+```
+
+Probe the saved server before relying on it:
+
+```bash
+openclaw mcp doctor atomicmail --probe
+```
+
+After `register`, create the required hourly inbox cron job:
+
+```bash
+openclaw cron add \
+  --name "atomicmail-inbox" \
+  --cron "0 * * * *" \
+  --session isolated \
+  --message 'Use Atomic Mail to fetch my inbox (MCP jmap_request with ops_file list_inbox.json, or atomicmail jmap_request --ops-file list_inbox.json). Summarize new messages, highlight what needs a reply, and stay available - I may ask you to reply, forward, search, or dig into something important.' \
+  --announce
+```
+
+## Why manual registration
+
+During this task, the documented OpenClaw package metadata and ClawHub publish
+commands were confirmed, but a stable documented plugin SDK hook for mutating
+OpenClaw MCP server config from inside the plugin was not confirmed. The same
+goes for a safe install-time cron mutation path. This wrapper therefore stays
+intentionally honest: it advertises the intended MCP runtime and prints the
+exact setup commands without pretending to automate unsupported steps.
+
+## Release flow
+
+This package is prepared by:
+
+```bash
+deno run -A ts/build_openclaw_wrapper.ts <version>
+```
+
+The GitHub Actions workflow `.github/workflows/publish-clawhub.yml` then:
+
+1. resolves the release version,
+2. builds and locally packs `integrations_dist/openclaw/atomicmail` for verification, and
+3. calls ClawHub's official reusable package publishing workflow against the
+   wrapper package path in this repo.

--- a/integrations/openclaw/atomicmail/bin/mcp-config.js
+++ b/integrations/openclaw/atomicmail/bin/mcp-config.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+const MCP_SERVER_NAME = "atomicmail";
+const MCP_RUNTIME_PACKAGE = "@atomicmail/mcp-clawhub";
+const AGENT_PROMPT =
+  "Use Atomic Mail to fetch my inbox (MCP jmap_request with ops_file " +
+  "list_inbox.json, or atomicmail jmap_request --ops-file list_inbox.json). " +
+  "Summarize new messages, highlight what needs a reply, and stay available - " +
+  "I may ask you to reply, forward, search, or dig into something important.";
+
+const config = {
+  command: "npx",
+  args: ["-y", MCP_RUNTIME_PACKAGE],
+};
+
+const lines = [
+  "# Atomic Mail OpenClaw setup",
+  "",
+  "Saved MCP config:",
+  JSON.stringify(config, null, 2),
+  "",
+  "Register the MCP server in OpenClaw:",
+  `openclaw mcp add ${MCP_SERVER_NAME} --command npx --arg -y --arg ${MCP_RUNTIME_PACKAGE}`,
+  "",
+  "Verify the saved server with a live probe:",
+  `openclaw mcp doctor ${MCP_SERVER_NAME} --probe`,
+  "",
+  "Required hourly inbox cron job:",
+  "openclaw cron add \\",
+  '  --name "atomicmail-inbox" \\',
+  '  --cron "0 * * * *" \\',
+  "  --session isolated \\",
+  `  --message '${AGENT_PROMPT}' \\`,
+  "  --announce",
+  "",
+  "Why this is manual:",
+  "This package intentionally does not claim silent install-time mutation of OpenClaw MCP or cron config.",
+];
+
+process.stdout.write(`${lines.join("\n")}\n`);

--- a/integrations/openclaw/atomicmail/openclaw.plugin.json
+++ b/integrations/openclaw/atomicmail/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "atomicmail",
+  "name": "Atomic Mail",
+  "description": "Thin OpenClaw wrapper that points users at the @atomicmail/mcp-clawhub MCP runtime.",
+  "version": "0.3.4",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/integrations/openclaw/atomicmail/package.json
+++ b/integrations/openclaw/atomicmail/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@atomicmail/openclaw-atomicmail",
+  "version": "0.3.4",
+  "description": "Thin OpenClaw/ClawHub wrapper for the Atomic Mail MCP server.",
+  "license": "MIT",
+  "type": "module",
+  "files": [
+    "dist",
+    "bin",
+    "openclaw.plugin.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "bin": {
+    "atomicmail-openclaw-mcp-config": "./bin/mcp-config.js"
+  },
+  "homepage": "https://atomicmail.ai?utm_source=clawhub&utm_medium=package&utm_campaign=openclaw-wrapper",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Atomic-Mail/agentic-clients.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Atomic-Mail/agentic-clients/issues"
+  },
+  "keywords": [
+    "atomic-mail",
+    "atomicmail",
+    "openclaw",
+    "clawhub",
+    "mcp",
+    "model-context-protocol",
+    "email",
+    "jmap"
+  ],
+  "peerDependencies": {
+    "openclaw": ">=2026.5.17"
+  },
+  "openclaw": {
+    "extensions": [
+      "./dist/index.js"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.5.17"
+    },
+    "build": {
+      "openclawVersion": "2026.5.17"
+    }
+  },
+  "atomicmail": {
+    "channel": "clawhub",
+    "runtimePackage": "@atomicmail/mcp-clawhub",
+    "wrapperPackage": true
+  }
+}

--- a/integrations/openclaw/atomicmail/src/index.js
+++ b/integrations/openclaw/atomicmail/src/index.js
@@ -1,0 +1,29 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const MCP_RUNTIME_PACKAGE = "@atomicmail/mcp-clawhub";
+
+/**
+ * Minimal OpenClaw plugin entry.
+ *
+ * This intentionally does not attempt automatic MCP registration because the
+ * exact stable plugin-side hook for mutating OpenClaw's MCP config was not
+ * verified during this task. The ClawHub package exists to give Atomic Mail a
+ * package/plugin presence while keeping the actual runtime in the MCP package.
+ */
+const plugin = definePluginEntry({
+  id: "atomicmail",
+  name: "Atomic Mail",
+  description:
+    "Thin wrapper package for the Atomic Mail MCP runtime on ClawHub/OpenClaw.",
+  register() {
+    // Keep setup explicit until OpenClaw documents a stable plugin-managed MCP
+    // registration hook and a safe cron creation surface for package install.
+  },
+});
+
+export const atomicmailMcpRuntime = {
+  command: "npx",
+  args: ["-y", MCP_RUNTIME_PACKAGE],
+};
+
+export default plugin;

--- a/ts/build_all_npm.ts
+++ b/ts/build_all_npm.ts
@@ -8,6 +8,7 @@ import {
   buildNpmPackage,
   getPackageName,
   loadChannels,
+  supportsChannelProduct,
 } from "./lib/build_npm.ts";
 import { parseReleaseVersion, syncSourceVersion } from "./lib/version.ts";
 import { ATOMICMAIL_MCP_VERSION } from "./src/mcp/version.ts";
@@ -24,10 +25,11 @@ const channels = loadChannels();
 const targets: Array<{ product: "mcp" | "skill"; channel?: string }> = [
   { product: "mcp" },
   { product: "skill" },
-  ...channels.flatMap((channel) => [
-    { product: "mcp" as const, channel },
-    { product: "skill" as const, channel },
-  ]),
+  ...channels.flatMap((channel) =>
+    (["mcp", "skill"] as const)
+      .filter((product) => supportsChannelProduct(channel, product))
+      .map((product) => ({ product, channel: channel.name }))
+  ),
 ];
 
 for (const target of targets) {
@@ -37,5 +39,5 @@ for (const target of targets) {
 }
 
 console.log(
-  `Done: ${targets.length} packages at version ${version} (default + ${channels.length} channels × 2 products).`,
+  `Done: ${targets.length} packages at version ${version} (${channels.length} configured channel entries).`,
 );

--- a/ts/build_openclaw_wrapper.ts
+++ b/ts/build_openclaw_wrapper.ts
@@ -1,0 +1,64 @@
+import { emptyDir } from "@deno/dnt";
+
+import { parseReleaseVersion } from "./lib/version.ts";
+import { ATOMICMAIL_MCP_VERSION } from "./src/mcp/version.ts";
+
+const ROOT = new URL("../", import.meta.url);
+const SOURCE_DIR = new URL(
+  "../integrations/openclaw/atomicmail/",
+  import.meta.url,
+);
+const OUT_DIR = new URL(
+  "../integrations_dist/openclaw/atomicmail/",
+  import.meta.url,
+);
+
+const rawVersion = Deno.args[0];
+const version = rawVersion
+  ? parseReleaseVersion(rawVersion)
+  : ATOMICMAIL_MCP_VERSION;
+
+async function copyDir(src: URL, dest: URL): Promise<void> {
+  await Deno.mkdir(dest, { recursive: true });
+  for await (const entry of Deno.readDir(src)) {
+    const srcPath = new URL(entry.name, src);
+    const destPath = new URL(entry.name, dest);
+    if (entry.isDirectory) {
+      await copyDir(new URL(`${entry.name}/`, src), new URL(`${entry.name}/`, dest));
+    } else if (entry.isFile) {
+      await Deno.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+function stampVersion(text: string): string {
+  return text.replace(/"version":\s*"[^"]+"/, `"version": "${version}"`);
+}
+
+async function stampVersionFile(path: URL): Promise<void> {
+  const text = await Deno.readTextFile(path);
+  await Deno.writeTextFile(path, stampVersion(text));
+}
+
+await stampVersionFile(new URL("package.json", SOURCE_DIR));
+await stampVersionFile(new URL("openclaw.plugin.json", SOURCE_DIR));
+
+await emptyDir(new URL("./", OUT_DIR).pathname);
+await copyDir(SOURCE_DIR, OUT_DIR);
+await Deno.copyFile(
+  new URL("LICENSE", ROOT),
+  new URL("LICENSE", OUT_DIR),
+);
+
+await stampVersionFile(new URL("package.json", OUT_DIR));
+await stampVersionFile(new URL("openclaw.plugin.json", OUT_DIR));
+
+await Deno.mkdir(new URL("dist/", OUT_DIR), { recursive: true });
+await Deno.copyFile(
+  new URL("src/index.js", OUT_DIR),
+  new URL("dist/index.js", OUT_DIR),
+);
+
+console.log(
+  `Built OpenClaw wrapper @atomicmail/openclaw-atomicmail@${version} -> ./integrations_dist/openclaw/atomicmail`,
+);

--- a/ts/lib/build_npm.ts
+++ b/ts/lib/build_npm.ts
@@ -6,6 +6,10 @@ import {
 } from "../npm_package_meta.ts";
 
 export type NpmProduct = "mcp" | "skill";
+export interface NpmChannelConfig {
+  name: string;
+  products?: NpmProduct[];
+}
 
 const PRESET_FILES = [
   "send_mail.json",
@@ -74,11 +78,45 @@ const GITHUB_PACKAGES = {
   },
 } as const;
 
-export function loadChannels(): string[] {
+function normalizeChannelConfig(
+  channel: string | NpmChannelConfig,
+): NpmChannelConfig {
+  if (typeof channel === "string") {
+    return { name: channel };
+  }
+  return channel;
+}
+
+export function loadChannels(): NpmChannelConfig[] {
   const text = Deno.readTextFileSync(
     new URL("../npm_channels.json", import.meta.url),
   );
-  return JSON.parse(text) as string[];
+  const parsed = JSON.parse(text) as Array<string | NpmChannelConfig>;
+  return parsed.map(normalizeChannelConfig);
+}
+
+export function supportsChannelProduct(
+  channel: NpmChannelConfig,
+  product: NpmProduct,
+): boolean {
+  return !channel.products || channel.products.includes(product);
+}
+
+export function assertChannelSupported(
+  product: NpmProduct,
+  channel?: string,
+): void {
+  if (!channel) return;
+
+  const config = loadChannels().find((entry) => entry.name === channel);
+  if (!config) {
+    throw new Error(`Unknown npm channel: ${channel}`);
+  }
+  if (!supportsChannelProduct(config, product)) {
+    throw new Error(
+      `Unsupported npm channel for ${product}: ${channel}`,
+    );
+  }
 }
 
 export function getOutputDir(product: NpmProduct, channel?: string): string {
@@ -147,6 +185,7 @@ export async function buildNpmPackage(
   options: BuildNpmPackageOptions,
 ): Promise<string> {
   const { product, version, channel, overrides } = options;
+  assertChannelSupported(product, channel);
   const config = PRODUCT_CONFIG[product];
   const dir = overrides?.outDir ?? getOutputDir(product, channel);
   const packageName = overrides?.packageName ??

--- a/ts/npm_channels.json
+++ b/ts/npm_channels.json
@@ -1,1 +1,8 @@
-["github", "modelcontextprotocol"]
+[
+  "github",
+  "modelcontextprotocol",
+  {
+    "name": "clawhub",
+    "products": ["mcp"]
+  }
+]


### PR DESCRIPTION
Add a ClawHub-specific MCP npm channel and scaffold an OpenClaw wrapper package plus release workflow so Atomic Mail can be published to ClawHub without shipping a ClawHub skill variant.