### PR TITLE
Align release skill publishing with unified tap artifacts.

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -1,8 +1,9 @@
 name: Publish ClawHub package
 
+# Legacy OpenClaw wrapper publish path. Release skill publishing now runs via
+# publish-skills.yml from integrations/skill/atomicmail.
+
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -86,8 +86,17 @@ jobs:
       - name: Build ClawHub and Hermes skill packages
         working-directory: ts
         run: |
+          deno run -A build_skill.ts "${{ steps.version.outputs.version }}"
           deno run -A build_clawhub_skill.ts "${{ steps.version.outputs.version }}"
           deno run -A build_hermes_skill.ts "${{ steps.version.outputs.version }}"
+
+      - name: Upload unified skill artifact
+        if: github.event_name == 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: unified-skill-atomicmail
+          path: dist/skill/atomicmail
+          if-no-files-found: error
 
       - name: Upload ClawHub skill artifact
         if: github.event_name == 'release'
@@ -127,12 +136,13 @@ jobs:
         working-directory: ts
         run: |
           deno run -A build_skill_npm.ts "${{ needs.build.outputs.version }}"
+          deno run -A build_skill.ts "${{ needs.build.outputs.version }}"
           deno run -A build_clawhub_skill.ts "${{ needs.build.outputs.version }}"
           deno run -A build_hermes_skill.ts "${{ needs.build.outputs.version }}"
 
       - name: Verify skill layout and launchers
         working-directory: ts
-        run: deno test --allow-read --allow-env --allow-write --allow-run clawhub_skill_build.test.ts hermes_skill_build.test.ts
+        run: deno test --allow-read --allow-env --allow-write --allow-run skill_build.test.ts clawhub_skill_build.test.ts hermes_skill_build.test.ts
 
   publish_clawhub:
     needs: [build, verify]
@@ -153,7 +163,7 @@ jobs:
       - name: Download ClawHub skill artifact
         uses: actions/download-artifact@v4
         with:
-          name: clawhub-skill-atomicmail
+          name: unified-skill-atomicmail
           path: skill
 
       - name: Setup Node.js
@@ -218,7 +228,7 @@ jobs:
       - name: Download Hermes skill artifact
         uses: actions/download-artifact@v4
         with:
-          name: hermes-skill-atomicmail
+          name: unified-skill-atomicmail
           path: skill
 
       - name: Sync skill to integrations/skill/atomicmail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Agent host → MCP or CLI → ts/src/lib → auth.atomicmail.ai → api.atomicma
 | `shared/` | Cross-language source of truth: presets, help topics, errors, consts |
 | `docs/` | VitePress user docs |
 | `py/` | Python library and tests |
-| `integrations/` | Channel wrappers (e.g. OpenClaw) |
+| `integrations/` | Published integration taps (for example `integrations/skill/atomicmail`) |
 
 **Edit cross-cutting content in `shared/` first**—presets, help topics, error keys, constants. npm builds bundle `shared/` into published packages. Do not edit generated `*_npm/` dirs (gitignored).
 
@@ -57,6 +57,7 @@ cd py && pytest
 - CLI → `ts/src/skill/`
 - Presets, help, errors → `shared/` (not duplicated TS/Python strings)
 - User-facing docs → `docs/` when behavior changes
+- In-repo skill tap output → `integrations/skill/atomicmail/` (CI-synced artifact; do not hand-edit)
 
 TypeScript style: 2-space indent, 80-column width (`ts/deno.json`).
 
@@ -76,6 +77,7 @@ TypeScript style: 2-space indent, 80-column width (`ts/deno.json`).
 
 - Canonical presets live in `shared/presets/`; legacy copies under `ts/src/lib/agent/jmap/presets/` are fallbacks only.
 - Help loads from `shared/help/topics/` at runtime; TS embedded fallbacks in `help-content/*.ts` can drift—prefer editing shared topics.
+- Release skill publishing uses unified `dist/skill/atomicmail/` output and then syncs `integrations/skill/atomicmail/` from that artifact.
 - Error messages: add keys to `shared/messages/errors.json`.
 - PoW salt uses UTF-8 bytes of the hex string, not `bytes.fromhex()`.
 - Prefer `help` topics over guessing JMAP details; runtime help may be more current than static docs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,9 @@ Build output: `dist/skill/atomicmail/` (gitignored). Published copies land in
 bootstrap once, then updated by CI).
 
 CI publish flow syncs the unified skill tap on release and manual dispatch.
+The release workflow now publishes ClawHub from the same unified artifact
+(`dist/skill/atomicmail/`) that is synced to
+`integrations/skill/atomicmail/`.
 
 Dry-run locally (build + verify only — same as CI `dry_run: true`):
 


### PR DESCRIPTION
Build and publish the release skill from the unified dist artifact, sync integrations/skill from that same output, and document the updated source-of-truth workflow.