### PR TITLE
Fix docs favicon path for GitHub Pages base URL.

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,6 +10,7 @@ const pagesBase = process.env.GITHUB_ACTIONS && repositoryName
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   base: pagesBase,
+  head: [["link", { rel: "icon", href: `${pagesBase}favicon.ico` }]],
   lang: "en-US",
   title: "Atomic Mail Agentic",
   description: "API, MCP and AgentSkill Documentation",


### PR DESCRIPTION
Add an explicit head icon link that prefixes favicon.ico with the configured VitePress base so the icon resolves on project-scoped pages.