### PR TITLE
Add @atomicmail/agentic-core npm package for integration hosts.

### DIFF
--- a/docs/core.md
+++ b/docs/core.md
@@ -1,0 +1,57 @@
+# @atomicmail/agentic-core
+
+Shared Atomic Mail runtime for integrations — PoW auth, JMAP batch execution, presets, and help topics.
+
+Use this package when building connectors (Activepieces, custom hosts) instead of shelling out to MCP or AgentSkill.
+
+## Install
+
+```bash
+npm install @atomicmail/agentic-core
+```
+
+## Quick start
+
+```typescript
+import {
+  createAgentSessionFromKeyValue,
+  runJmapRequest,
+  getHelp,
+} from "@atomicmail/agentic-core";
+
+const session = await createAgentSessionFromKeyValue({
+  storage: myHostKeyValueStore,
+  accountId: "default",
+  apiKey: process.env.ATOMIC_MAIL_API_KEY,
+});
+
+const result = await session.register("myagent01");
+// result.apiKey — present on first signup
+
+const jmap = await runJmapRequest({
+  session,
+  opsJson: await Deno.readTextFile("presets/list_inbox.json"),
+  defaultUsing: ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+  sourceLabel: "list_inbox.json",
+});
+
+const help = await getHelp("presets");
+```
+
+## Key exports
+
+- `AgentSession` — register, JWT refresh, JMAP session cache
+- `runJmapRequest` — preset/ops execution with `$VAR` substitution and attachments
+- `getHelp`, `HELP_TOPIC_LIST` — runtime help topics
+- `KeyValueCredentialStore` — persist credentials in host storage (Activepieces Store, etc.)
+- `createAgentSession`, `createAgentSessionFromKeyValue` — integration session factory
+
+Bundled assets: `shared/` presets and help topics, `presets/` JMAP JSON files.
+
+## PoW / timeout guidance for integration hosts
+
+- Run PoW in **flow actions** (register, jmap_request), not in connection `validate()`.
+- Cache session JWTs in host storage; PoW re-runs only when JWT expires (~1h).
+- Do not use sync webhooks for register or other PoW-heavy steps.
+
+See the Atomic Mail Agentic repo for full integration guidelines.

--- a/ts/build_core_npm.ts
+++ b/ts/build_core_npm.ts
@@ -1,0 +1,19 @@
+// Build the @atomicmail/agentic-core npm package using dnt.
+//
+// Usage:
+//   deno run -A build_core_npm.ts [version]
+
+import {
+  buildNpmPackage,
+  getPackageName,
+  parseBuildArgs,
+} from "./lib/build_npm.ts";
+import { ATOMICMAIL_MCP_VERSION } from "./src/mcp/version.ts";
+
+const { version: argVersion } = parseBuildArgs(Deno.args);
+const version = (argVersion ?? ATOMICMAIL_MCP_VERSION).replace(/^v/, "");
+
+const dir = await buildNpmPackage({ product: "core", version });
+const packageName = getPackageName("core");
+
+console.log(`Built ${packageName}@${version} -> ./${dir}`);

--- a/ts/lib/build_npm.ts
+++ b/ts/lib/build_npm.ts
@@ -17,7 +17,7 @@ type NpmEntryPoint =
     path: string;
   };
 
-export type NpmProduct = "mcp" | "skill" | "langchain";
+export type NpmProduct = "mcp" | "skill" | "langchain" | "core";
 interface ExtraFile {
   path: string;
   targetPath: string;
@@ -132,6 +132,27 @@ const PRODUCT_CONFIG: Record<NpmProduct, ProductConfigEntry> = {
       },
     },
   },
+  core: {
+    baseName: "@atomicmail/agentic-core",
+    entryPoint: {
+      kind: "module",
+      path: "./src/lib/mod.ts",
+    } satisfies NpmEntryPoint,
+    description:
+      "Atomic Mail agentic core — PoW auth, JMAP, presets, and help for integration hosts.",
+    keywords: [
+      "atomic-mail",
+      "atomicmail",
+      "agentic",
+      "core",
+      "jmap",
+      "email",
+      "proof-of-work",
+      "integration",
+    ],
+    readme: { path: "../docs/core.md", targetPath: "README.md" },
+    extraFiles: [],
+  },
 };
 
 const GITHUB_PACKAGES = {
@@ -146,6 +167,10 @@ const GITHUB_PACKAGES = {
   langchain: {
     packageName: "@atomic-mail/langchain",
     outDir: "langchain_npm_gpr",
+  },
+  core: {
+    packageName: "@atomic-mail/agentic-core",
+    outDir: "core_npm_gpr",
   },
 } as const;
 
@@ -191,8 +216,8 @@ export function assertChannelSupported(
   channel?: string,
 ): void {
   if (!channel) return;
-  if (product === "langchain") {
-    throw new Error("Unsupported npm channel for langchain");
+  if (product === "langchain" || product === "core") {
+    throw new Error(`Unsupported npm channel for ${product}`);
   }
 
   const config = getChannelConfig(channel);
@@ -211,6 +236,8 @@ export function getOutputDir(product: NpmProduct, channel?: string): string {
     ? "mcp_npm"
     : product === "skill"
     ? "skill_npm"
+    : product === "core"
+    ? "core_npm"
     : "langchain_npm";
   return channel ? `${prefix}_${channel}` : prefix;
 }
@@ -218,6 +245,9 @@ export function getOutputDir(product: NpmProduct, channel?: string): string {
 export function getPackageName(product: NpmProduct, channel?: string): string {
   if (product === "langchain" && channel) {
     throw new Error("Unsupported npm channel for langchain");
+  }
+  if (product === "core" && channel) {
+    throw new Error("Unsupported npm channel for core");
   }
   const { baseName } = PRODUCT_CONFIG[product];
   return channel ? `${baseName}-${channel}` : baseName;
@@ -236,6 +266,7 @@ export function listConfiguredPackageTargets(
     { product: "mcp" },
     { product: "skill" },
     { product: "langchain" },
+    { product: "core" },
   ];
 
   for (const channel of loadChannels()) {
@@ -365,7 +396,7 @@ export async function buildNpmPackage(
       deno: false,
     },
     test: false,
-    scriptModule: false,
+    scriptModule: product === "core" ? "commonjs" : false,
     typeCheck: false,
     compilerOptions: {
       lib: ["ES2022", "DOM"],
@@ -436,7 +467,7 @@ export async function buildGithubPackagesNpm(
   version: string,
 ): Promise<string[]> {
   const dirs: string[] = [];
-  for (const product of ["mcp", "skill", "langchain"] as const) {
+  for (const product of ["mcp", "skill", "langchain", "core"] as const) {
     const gpr = GITHUB_PACKAGES[product];
     const config = PRODUCT_CONFIG[product];
     const dir = await buildNpmPackage({
@@ -456,7 +487,7 @@ export async function buildGithubPackagesNpm(
 }
 
 export function listGithubPackagesDirs(): string[] {
-  return ["langchain_npm_gpr", "mcp_npm_gpr", "skill_npm_gpr"];
+  return ["langchain_npm_gpr", "mcp_npm_gpr", "skill_npm_gpr", "core_npm_gpr"];
 }
 
 export interface ParsedBuildArgs {

--- a/ts/src/lib/integrations/create-agent-session.ts
+++ b/ts/src/lib/integrations/create-agent-session.ts
@@ -1,0 +1,79 @@
+// Create AgentSession for integration hosts (Activepieces, Dify-style runtimes).
+
+import {
+  DEFAULT_API_URL,
+  DEFAULT_AUTH_URL,
+  DEFAULT_POW_SCRYPT_SALT_HEX,
+} from "../core/consts.ts";
+import { AgentSession } from "../agent/session/agent-session.ts";
+import type { CredentialStore } from "../agent/session/agent-credentials-store.ts";
+import {
+  KeyValueCredentialStore,
+  type KeyValueStore,
+} from "./key-value-credential-store.ts";
+
+export interface IntegrationEnv {
+  authUrl?: string;
+  apiUrl?: string;
+  scryptSalt?: string;
+}
+
+export interface CreateAgentSessionInput {
+  store: CredentialStore;
+  env?: IntegrationEnv;
+  apiKey?: string;
+  /** Virtual credential namespace label (for logging / parity). */
+  credentialDir?: string;
+}
+
+export interface CreateAgentSessionFromKeyValueInput {
+  storage: KeyValueStore;
+  accountId?: string;
+  env?: IntegrationEnv;
+  apiKey?: string;
+  credentialDir?: string;
+}
+
+function resolveIntegrationEnv(env?: IntegrationEnv): {
+  authUrl: string;
+  apiUrl: string;
+  scryptSalt: string;
+} {
+  return {
+    authUrl: (env?.authUrl ?? DEFAULT_AUTH_URL).replace(/\/+$/, ""),
+    apiUrl: (env?.apiUrl ?? DEFAULT_API_URL).replace(/\/+$/, ""),
+    scryptSalt: env?.scryptSalt ?? DEFAULT_POW_SCRYPT_SALT_HEX,
+  };
+}
+
+export async function createAgentSession(
+  input: CreateAgentSessionInput,
+): Promise<AgentSession> {
+  const resolved = resolveIntegrationEnv(input.env);
+  const loaded = await input.store.load();
+  const creds = loaded.credentials;
+
+  return AgentSession.create({
+    authUrl: creds?.authUrl ?? resolved.authUrl,
+    apiUrl: creds?.apiUrl ?? resolved.apiUrl,
+    scryptSalt: creds?.scryptSalt ?? resolved.scryptSalt,
+    apiKey: input.apiKey ?? creds?.apiKey,
+    inboxId: creds?.inboxId,
+    credentialDir: input.credentialDir ?? "integration://default",
+    store: input.store,
+  });
+}
+
+export async function createAgentSessionFromKeyValue(
+  input: CreateAgentSessionFromKeyValueInput,
+): Promise<AgentSession> {
+  const accountId = input.accountId ?? "default";
+  const store = new KeyValueCredentialStore(input.storage, accountId);
+  return createAgentSession({
+    store,
+    env: input.env,
+    apiKey: input.apiKey,
+    credentialDir: input.credentialDir ??
+      `integration://account/${accountId}`,
+  });
+}

--- a/ts/src/lib/integrations/integrations.test.ts
+++ b/ts/src/lib/integrations/integrations.test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "@std/assert";
+import {
+  KeyValueCredentialStore,
+  type KeyValueStore,
+} from "./key-value-credential-store.ts";
+import { createAgentSessionFromKeyValue } from "./create-agent-session.ts";
+
+class MemoryKv implements KeyValueStore {
+  private data = new Map<string, string>();
+
+  get(key: string): Promise<string | undefined> {
+    return Promise.resolve(this.data.get(key));
+  }
+
+  set(key: string, value: string): Promise<void> {
+    this.data.set(key, value);
+    return Promise.resolve();
+  }
+
+  delete(key: string): Promise<void> {
+    this.data.delete(key);
+    return Promise.resolve();
+  }
+
+  has(key: string): Promise<boolean> {
+    return Promise.resolve(this.data.has(key));
+  }
+}
+
+Deno.test("KeyValueCredentialStore round-trips credentials and JWTs", async () => {
+  const kv = new MemoryKv();
+  const store = new KeyValueCredentialStore(kv, "acct1");
+
+  await store.save({
+    credentials: {
+      apiKey: "key-123",
+      inboxId: "user@atomicmail.ai",
+      authUrl: "https://auth.atomicmail.ai",
+      apiUrl: "https://api.atomicmail.ai",
+      scryptSalt: "abc",
+      uploadUrl: "https://api.atomicmail.ai/upload",
+      downloadUrl: "https://api.atomicmail.ai/download",
+    },
+    sessionJwt: "session.jwt",
+    capabilityJwt: "capability.jwt",
+  });
+
+  const loaded = await store.load();
+  assertEquals(loaded.credentials?.apiKey, "key-123");
+  assertEquals(loaded.sessionJwt, "session.jwt");
+  assertEquals(loaded.capabilityJwt, "capability.jwt");
+
+  await store.clear();
+  const cleared = await store.load();
+  assertEquals(cleared.credentials, undefined);
+  assertEquals(cleared.sessionJwt, undefined);
+  assertEquals(cleared.capabilityJwt, undefined);
+});
+
+Deno.test("createAgentSessionFromKeyValue uses env defaults", async () => {
+  const session = await createAgentSessionFromKeyValue({
+    storage: new MemoryKv(),
+    accountId: "default",
+  });
+  assertEquals(session.hasApiKey, false);
+  assertEquals(session.credentialDir, "integration://account/default");
+});

--- a/ts/src/lib/integrations/key-value-credential-store.ts
+++ b/ts/src/lib/integrations/key-value-credential-store.ts
@@ -1,0 +1,98 @@
+// Credential persistence backed by a host-provided key-value store (Dify, Activepieces, …).
+
+import {
+  type CredentialArtifacts,
+  type CredentialStore,
+  type Credentials,
+  parseCredentialsJson,
+  serializeCredentials,
+} from "../agent/session/agent-credentials-store.ts";
+
+export interface KeyValueStore {
+  get(key: string): Promise<string | undefined>;
+  set(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
+  has?(key: string): Promise<boolean>;
+}
+
+export class KeyValueCredentialStore implements CredentialStore {
+  constructor(
+    private readonly storage: KeyValueStore,
+    private readonly accountId = "default",
+  ) {}
+
+  private key(suffix: string): string {
+    return `account:${this.accountId}:${suffix}`;
+  }
+
+  private get credentialsKey(): string {
+    return this.key("credentials.json");
+  }
+
+  private get sessionKey(): string {
+    return this.key("session.jwt");
+  }
+
+  private get capabilityKey(): string {
+    return this.key("capability.jwt");
+  }
+
+  private async exists(key: string): Promise<boolean> {
+    if (this.storage.has) {
+      return this.storage.has(key);
+    }
+    const value = await this.storage.get(key);
+    return value !== undefined;
+  }
+
+  async load(): Promise<CredentialArtifacts> {
+    let credentials: Credentials | undefined;
+    const rawCredentials = await this.storage.get(this.credentialsKey);
+    if (rawCredentials) {
+      try {
+        credentials = parseCredentialsJson(
+          rawCredentials,
+          this.credentialsKey,
+        );
+      } catch {
+        credentials = undefined;
+      }
+    }
+
+    const sessionJwt = await this.storage.get(this.sessionKey);
+    const capabilityJwt = await this.storage.get(this.capabilityKey);
+
+    return {
+      credentials,
+      sessionJwt,
+      capabilityJwt,
+    };
+  }
+
+  async save(artifacts: CredentialArtifacts): Promise<void> {
+    if (artifacts.credentials !== undefined) {
+      await this.storage.set(
+        this.credentialsKey,
+        serializeCredentials(artifacts.credentials),
+      );
+    }
+    if (artifacts.sessionJwt !== undefined) {
+      await this.storage.set(this.sessionKey, artifacts.sessionJwt);
+    }
+    if (artifacts.capabilityJwt !== undefined) {
+      await this.storage.set(this.capabilityKey, artifacts.capabilityJwt);
+    }
+  }
+
+  async clear(): Promise<void> {
+    for (const key of [this.credentialsKey, this.sessionKey, this.capabilityKey]) {
+      try {
+        if (await this.exists(key)) {
+          await this.storage.delete(key);
+        }
+      } catch {
+        // non-fatal
+      }
+    }
+  }
+}

--- a/ts/src/lib/mod.ts
+++ b/ts/src/lib/mod.ts
@@ -18,3 +18,6 @@ export * from "./agent/session/agent-resolve-config.ts";
 export * from "./agent/session/agent-session-for-dir.ts";
 export * from "./agent/jmap/agent-help-content.ts";
 export * from "./agent/jmap/agent-vars.ts";
+
+export * from "./integrations/key-value-credential-store.ts";
+export * from "./integrations/create-agent-session.ts";


### PR DESCRIPTION
Expose KV-backed session helpers and a CommonJS npm build so connectors like Activepieces can reuse the shared runtime without MCP/CLI wrappers.