### PR TITLE
Fix n8n Creator Portal credential test vetting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ node_modules/
 dist/
 **/dist/
 
-# n8n Creator Portal vetting — minimal committed dist/*.js + repo-root symlinks
+# n8n Creator Portal vetting — minimal committed dist/*.js + repo-root copies
 !integrations/n8n/atomicmail/dist/
 !integrations/n8n/atomicmail/dist/credentials/
 !integrations/n8n/atomicmail/dist/credentials/AtomicMailApi.credentials.js

--- a/credentials/AtomicMailApi.credentials.ts
+++ b/credentials/AtomicMailApi.credentials.ts
@@ -1,1 +1,65 @@
-../integrations/n8n/atomicmail/credentials/AtomicMailApi.credentials.ts
+import type {
+	Icon,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class AtomicMailApi implements ICredentialType {
+	name = 'atomicMailApi';
+
+	displayName = 'Atomic Mail API';
+
+	icon: Icon = {
+		light: 'file:../icons/atomicmail.svg',
+		dark: 'file:../icons/atomicmail.dark.svg',
+	};
+
+	documentationUrl =
+		'https://github.com/Atomic-Mail/atomic-mail-agentic/blob/develop/docs/n8n.md';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			default: '',
+			description:
+				'Optional. Leave empty after **Register** (credentials are saved in workflow static data), or paste an existing Atomic Mail API key.',
+		},
+		{
+			displayName: 'Auth URL',
+			name: 'authUrl',
+			type: 'string',
+			default: 'https://auth.atomicmail.ai',
+			description: 'Auth service base URL (default https://auth.atomicmail.ai).',
+		},
+		{
+			displayName: 'API URL',
+			name: 'apiUrl',
+			type: 'string',
+			default: 'https://api.atomicmail.ai',
+			description: 'JMAP API base URL (default https://api.atomicmail.ai).',
+		},
+	];
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials.apiUrl || "https://api.atomicmail.ai"}}',
+			url: '/.well-known/jmap',
+			method: 'GET',
+		},
+		rules: [
+			{
+				type: 'responseCode',
+				properties: {
+					value: 200,
+					message: 'Could not reach the Atomic Mail JMAP endpoint.',
+				},
+			},
+		],
+	};
+}

--- a/dist/credentials/AtomicMailApi.credentials.js
+++ b/dist/credentials/AtomicMailApi.credentials.js
@@ -1,1 +1,58 @@
-../../integrations/n8n/atomicmail/dist/credentials/AtomicMailApi.credentials.js
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AtomicMailApi = void 0;
+class AtomicMailApi {
+    constructor() {
+        this.name = 'atomicMailApi';
+        this.displayName = 'Atomic Mail API';
+        this.icon = {
+            light: 'file:../icons/atomicmail.svg',
+            dark: 'file:../icons/atomicmail.dark.svg',
+        };
+        this.documentationUrl = 'https://github.com/Atomic-Mail/atomic-mail-agentic/blob/develop/docs/n8n.md';
+        this.properties = [
+            {
+                displayName: 'API Key',
+                name: 'apiKey',
+                type: 'string',
+                typeOptions: {
+                    password: true,
+                },
+                default: '',
+                description: 'Optional. Leave empty after **Register** (credentials are saved in workflow static data), or paste an existing Atomic Mail API key.',
+            },
+            {
+                displayName: 'Auth URL',
+                name: 'authUrl',
+                type: 'string',
+                default: 'https://auth.atomicmail.ai',
+                description: 'Auth service base URL (default https://auth.atomicmail.ai).',
+            },
+            {
+                displayName: 'API URL',
+                name: 'apiUrl',
+                type: 'string',
+                default: 'https://api.atomicmail.ai',
+                description: 'JMAP API base URL (default https://api.atomicmail.ai).',
+            },
+        ];
+        this.test = {
+            request: {
+                baseURL: '={{$credentials.apiUrl || "https://api.atomicmail.ai"}}',
+                url: '/.well-known/jmap',
+                method: 'GET',
+            },
+            rules: [
+                {
+                    type: 'responseCode',
+                    properties: {
+                        value: 200,
+                        message: 'Could not reach the Atomic Mail JMAP endpoint.',
+                    },
+                },
+            ],
+        };
+    }
+}
+exports.AtomicMailApi = AtomicMailApi;
+//# sourceMappingURL=AtomicMailApi.credentials.js.map

--- a/dist/nodes/AtomicMail/AtomicMail.node.js
+++ b/dist/nodes/AtomicMail/AtomicMail.node.js
@@ -1,1 +1,452 @@
-../../../integrations/n8n/atomicmail/dist/nodes/AtomicMail/AtomicMail.node.js
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AtomicMail = void 0;
+const n8n_workflow_1 = require("n8n-workflow");
+const index_js_1 = require("../../vendor/agentic-core/index.js");
+const attachments_1 = require("../../lib/attachments");
+const jmap_1 = require("../../lib/jmap");
+const session_1 = require("../../lib/session");
+const props_1 = require("../../lib/props");
+function unwrapJmapResult(context, itemIndex, result) {
+    if (!result.ok) {
+        throw new n8n_workflow_1.NodeOperationError(context.getNode(), result.message, { itemIndex });
+    }
+    return { status: result.status, body: result.body };
+}
+class AtomicMail {
+    constructor() {
+        this.description = {
+            displayName: 'Atomic Mail',
+            name: 'atomicMail',
+            icon: {
+                light: 'file:../../icons/atomicmail.svg',
+                dark: 'file:../../icons/atomicmail.dark.svg',
+            },
+            group: ['transform'],
+            version: 1,
+            subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
+            description: 'Programmable @atomicmail.ai inbox for agents — register, list inbox, send, reply, and raw JMAP.',
+            defaults: {
+                name: 'Atomic Mail',
+            },
+            inputs: [n8n_workflow_1.NodeConnectionTypes.Main],
+            outputs: [n8n_workflow_1.NodeConnectionTypes.Main],
+            usableAsTool: true,
+            credentials: [
+                {
+                    name: 'atomicMailApi',
+                    required: false,
+                },
+            ],
+            properties: [
+                {
+                    displayName: 'Resource',
+                    name: 'resource',
+                    type: 'options',
+                    noDataExpression: true,
+                    options: [
+                        { name: 'Account', value: 'account' },
+                        { name: 'Email', value: 'email' },
+                        { name: 'Help', value: 'help' },
+                        { name: 'Inbox', value: 'inbox' },
+                        { name: 'JMAP', value: 'jmap' },
+                    ],
+                    default: 'inbox',
+                },
+                {
+                    displayName: 'Operation',
+                    name: 'operation',
+                    type: 'options',
+                    noDataExpression: true,
+                    displayOptions: {
+                        show: { resource: ['account'] },
+                    },
+                    options: [{ name: 'Register', value: 'register', action: 'Register an inbox' }],
+                    default: 'register',
+                },
+                {
+                    displayName: 'Operation',
+                    name: 'operation',
+                    type: 'options',
+                    noDataExpression: true,
+                    displayOptions: {
+                        show: { resource: ['inbox'] },
+                    },
+                    options: [{ name: 'List', value: 'list', action: 'List inbox messages' }],
+                    default: 'list',
+                },
+                {
+                    displayName: 'Operation',
+                    name: 'operation',
+                    type: 'options',
+                    noDataExpression: true,
+                    displayOptions: {
+                        show: { resource: ['email'] },
+                    },
+                    options: [
+                        { name: 'Reply', value: 'reply', action: 'Reply to an email' },
+                        { name: 'Send', value: 'send', action: 'Send an email' },
+                    ],
+                    default: 'send',
+                },
+                {
+                    displayName: 'Operation',
+                    name: 'operation',
+                    type: 'options',
+                    noDataExpression: true,
+                    displayOptions: {
+                        show: { resource: ['jmap'] },
+                    },
+                    options: [{ name: 'Request', value: 'request', action: 'Send a JMAP request' }],
+                    default: 'request',
+                },
+                {
+                    displayName: 'Operation',
+                    name: 'operation',
+                    type: 'options',
+                    noDataExpression: true,
+                    displayOptions: {
+                        show: { resource: ['help'] },
+                    },
+                    options: [{ name: 'Get Topic', value: 'get', action: 'Get a help topic' }],
+                    default: 'get',
+                },
+                {
+                    displayName: 'Account Namespace',
+                    name: 'accountId',
+                    type: 'string',
+                    default: 'default',
+                    description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes in this workflow',
+                    displayOptions: {
+                        hide: { resource: ['help'] },
+                    },
+                },
+                {
+                    displayName: 'API Key (Optional Override)',
+                    name: 'apiKey',
+                    type: 'string',
+                    typeOptions: { password: true },
+                    default: '',
+                    description: 'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
+                    displayOptions: {
+                        hide: { resource: ['account', 'help'] },
+                    },
+                },
+                {
+                    displayName: 'Username',
+                    name: 'username',
+                    type: 'string',
+                    default: '',
+                    required: true,
+                    description: 'Desired inbox username (5–21 characters, before @atomicmail.ai)',
+                    displayOptions: {
+                        show: { resource: ['account'], operation: ['register'] },
+                    },
+                },
+                {
+                    displayName: 'Forced',
+                    name: 'forced',
+                    type: 'boolean',
+                    default: false,
+                    description: 'Whether to replace existing credentials in this account namespace after backing them up',
+                    displayOptions: {
+                        show: { resource: ['account'], operation: ['register'] },
+                    },
+                },
+                {
+                    displayName: 'To',
+                    name: 'to',
+                    type: 'string',
+                    default: '',
+                    required: true,
+                    displayOptions: {
+                        show: { resource: ['email'], operation: ['send'] },
+                    },
+                },
+                {
+                    displayName: 'Subject',
+                    name: 'subject',
+                    type: 'string',
+                    default: '',
+                    required: true,
+                    displayOptions: {
+                        show: { resource: ['email'], operation: ['send'] },
+                    },
+                },
+                {
+                    displayName: 'Body',
+                    name: 'body',
+                    type: 'string',
+                    typeOptions: { rows: 4 },
+                    default: '',
+                    required: true,
+                    displayOptions: {
+                        show: { resource: ['email'], operation: ['send', 'reply'] },
+                    },
+                },
+                {
+                    displayName: 'Binary Property',
+                    name: 'binaryProperty',
+                    type: 'string',
+                    default: '',
+                    description: 'Optional input binary field name to attach to the outgoing message',
+                    displayOptions: {
+                        show: { resource: ['email'], operation: ['send'] },
+                    },
+                },
+                {
+                    displayName: 'Mail ID',
+                    name: 'mailId',
+                    type: 'string',
+                    default: '',
+                    required: true,
+                    displayOptions: {
+                        show: { resource: ['email'], operation: ['reply'] },
+                    },
+                },
+                {
+                    displayName: 'Request Source',
+                    name: 'requestSource',
+                    type: 'options',
+                    options: [
+                        { name: 'Inline Ops JSON', value: 'inline' },
+                        { name: 'Preset File', value: 'preset' },
+                    ],
+                    default: 'preset',
+                    displayOptions: {
+                        show: { resource: ['jmap'], operation: ['request'] },
+                    },
+                },
+                {
+                    displayName: 'Ops JSON',
+                    name: 'ops',
+                    type: 'json',
+                    default: '',
+                    description: 'Inline JMAP methodCalls JSON or envelope object',
+                    displayOptions: {
+                        show: {
+                            resource: ['jmap'],
+                            operation: ['request'],
+                            requestSource: ['inline'],
+                        },
+                    },
+                },
+                {
+                    displayName: 'Ops File',
+                    name: 'opsFile',
+                    type: 'options',
+                    options: [
+                        { name: 'list_inbox.json', value: 'list_inbox.json' },
+                        { name: 'reply.json', value: 'reply.json' },
+                        { name: 'send_mail_attachment.json', value: 'send_mail_attachment.json' },
+                        {
+                            name: 'send_mail_blob_attachment.json',
+                            value: 'send_mail_blob_attachment.json',
+                        },
+                        { name: 'send_mail.json', value: 'send_mail.json' },
+                    ],
+                    default: 'list_inbox.json',
+                    description: 'Bundled preset filename from agentic-core',
+                    displayOptions: {
+                        show: {
+                            resource: ['jmap'],
+                            operation: ['request'],
+                            requestSource: ['preset'],
+                        },
+                    },
+                },
+                {
+                    displayName: 'Vars JSON',
+                    name: 'vars',
+                    type: 'json',
+                    default: '',
+                    description: 'Optional JSON object of $VAR placeholders (keys without $)',
+                    displayOptions: {
+                        show: { resource: ['jmap'], operation: ['request'] },
+                    },
+                },
+                {
+                    displayName: 'Dry Run',
+                    name: 'dryRun',
+                    type: 'boolean',
+                    default: false,
+                    description: 'Whether to validate the batch without sending (cannot be used with attachments)',
+                    displayOptions: {
+                        show: { resource: ['jmap'], operation: ['request'] },
+                    },
+                },
+                {
+                    displayName: 'Topic',
+                    name: 'topic',
+                    type: 'options',
+                    options: [
+                        { name: 'Auth', value: 'auth' },
+                        { name: 'Cron', value: 'cron' },
+                        { name: 'Installation', value: 'installation' },
+                        { name: 'JMAP Cheatsheet', value: 'jmap_cheatsheet' },
+                        { name: 'Multi Account', value: 'multi_account' },
+                        { name: 'Overview', value: 'overview' },
+                        { name: 'Presets', value: 'presets' },
+                        { name: 'Readme', value: 'readme' },
+                        { name: 'Tools', value: 'tools' },
+                        { name: 'Troubleshooting', value: 'troubleshooting' },
+                    ],
+                    default: 'overview',
+                    description: `Built-in docs. Topics: ${index_js_1.HELP_TOPIC_LIST.join(', ')}, readme.`,
+                    displayOptions: {
+                        show: { resource: ['help'], operation: ['get'] },
+                    },
+                },
+            ],
+        };
+    }
+    async execute() {
+        var _a;
+        const items = this.getInputData();
+        const returnData = [];
+        for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+            try {
+                const resource = this.getNodeParameter('resource', itemIndex);
+                const operation = this.getNodeParameter('operation', itemIndex);
+                const staticData = this.getWorkflowStaticData('global');
+                if (resource === 'help' && operation === 'get') {
+                    const topic = this.getNodeParameter('topic', itemIndex);
+                    const text = await (0, index_js_1.getHelp)(topic, 'skill');
+                    returnData.push({
+                        json: { topic, text },
+                        pairedItem: { item: itemIndex },
+                    });
+                    continue;
+                }
+                const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', itemIndex));
+                const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
+                const inlineApiKey = this.getNodeParameter('apiKey', itemIndex, '');
+                if (resource === 'account' && operation === 'register') {
+                    const username = (0, props_1.requiredString)(this.getNodeParameter('username', itemIndex), 'username');
+                    const forced = this.getNodeParameter('forced', itemIndex, false);
+                    const session = await (0, session_1.resolveSessionForExecute)(staticData, accountId, credentials, inlineApiKey, false);
+                    const result = await session.register(username, { forced });
+                    returnData.push({
+                        json: {
+                            ...result,
+                            _next: [index_js_1.postRegisterCronReminder],
+                        },
+                        pairedItem: { item: itemIndex },
+                    });
+                    continue;
+                }
+                const session = await (0, session_1.resolveSessionForExecute)(staticData, accountId, credentials, inlineApiKey, true);
+                if (resource === 'inbox' && operation === 'list') {
+                    const result = unwrapJmapResult(this, itemIndex, await (0, jmap_1.executePreset)(session, 'list_inbox.json'));
+                    returnData.push({
+                        json: {
+                            ok: true,
+                            status: result.status,
+                            body: result.body,
+                        },
+                        pairedItem: { item: itemIndex },
+                    });
+                    continue;
+                }
+                if (resource === 'email' && operation === 'send') {
+                    const to = (0, props_1.requiredString)(this.getNodeParameter('to', itemIndex), 'to');
+                    const subject = (0, props_1.requiredString)(this.getNodeParameter('subject', itemIndex), 'subject');
+                    const body = (0, props_1.requiredString)(this.getNodeParameter('body', itemIndex), 'body');
+                    const binaryProperty = (0, props_1.optionalTrimmedString)(this.getNodeParameter('binaryProperty', itemIndex, ''));
+                    const attachmentResult = await (0, attachments_1.attachmentVarsFromBinaryProperty)(this, session, itemIndex, binaryProperty);
+                    if (!attachmentResult.ok) {
+                        throw new n8n_workflow_1.NodeOperationError(this.getNode(), attachmentResult.message, {
+                            itemIndex,
+                        });
+                    }
+                    const vars = {
+                        TO: to,
+                        SUBJECT: subject,
+                        BODY: body,
+                        ...((_a = attachmentResult.vars) !== null && _a !== void 0 ? _a : {}),
+                    };
+                    const result = unwrapJmapResult(this, itemIndex, await (0, jmap_1.executePreset)(session, attachmentResult.vars
+                        ? 'send_mail_blob_attachment.json'
+                        : 'send_mail.json', vars));
+                    returnData.push({
+                        json: {
+                            ok: true,
+                            status: result.status,
+                            body: result.body,
+                        },
+                        pairedItem: { item: itemIndex },
+                    });
+                    continue;
+                }
+                if (resource === 'email' && operation === 'reply') {
+                    const mailId = (0, props_1.requiredString)(this.getNodeParameter('mailId', itemIndex), 'mailId');
+                    const body = (0, props_1.requiredString)(this.getNodeParameter('body', itemIndex), 'body');
+                    const result = unwrapJmapResult(this, itemIndex, await (0, jmap_1.executePreset)(session, 'reply.json', {
+                        MAIL_ID: mailId,
+                        BODY: body,
+                    }));
+                    returnData.push({
+                        json: {
+                            ok: true,
+                            status: result.status,
+                            body: result.body,
+                        },
+                        pairedItem: { item: itemIndex },
+                    });
+                    continue;
+                }
+                if (resource === 'jmap' && operation === 'request') {
+                    const requestSource = this.getNodeParameter('requestSource', itemIndex, 'preset');
+                    const dryRun = this.getNodeParameter('dryRun', itemIndex, false);
+                    const parsedVars = (0, jmap_1.parseVarsJson)(this.getNodeParameter('vars', itemIndex, ''));
+                    if (!parsedVars.ok) {
+                        throw new n8n_workflow_1.NodeOperationError(this.getNode(), parsedVars.message, { itemIndex });
+                    }
+                    let jmapResult;
+                    if (requestSource === 'inline') {
+                        const opsParam = this.getNodeParameter('ops', itemIndex, '');
+                        const opsJson = typeof opsParam === 'string'
+                            ? (0, props_1.optionalTrimmedString)(opsParam)
+                            : opsParam && typeof opsParam === 'object'
+                                ? JSON.stringify(opsParam)
+                                : undefined;
+                        if (!opsJson) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), (0, index_js_1.sharedError)('mcp_ops_required'), {
+                                itemIndex,
+                            });
+                        }
+                        jmapResult = await (0, jmap_1.executeOpsJson)(session, opsJson, parsedVars.vars, dryRun);
+                    }
+                    else {
+                        const opsFile = (0, props_1.requiredString)(this.getNodeParameter('opsFile', itemIndex, ''), 'opsFile');
+                        jmapResult = await (0, jmap_1.executePreset)(session, opsFile, parsedVars.vars, { dryRun });
+                    }
+                    const result = unwrapJmapResult(this, itemIndex, jmapResult);
+                    returnData.push({
+                        json: {
+                            ok: true,
+                            status: result.status,
+                            body: result.body,
+                        },
+                        pairedItem: { item: itemIndex },
+                    });
+                    continue;
+                }
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), `Unsupported operation ${resource}/${operation}.`, { itemIndex });
+            }
+            catch (error) {
+                if (this.continueOnFail()) {
+                    returnData.push({
+                        json: { error: error instanceof Error ? error.message : String(error) },
+                        pairedItem: { item: itemIndex },
+                    });
+                    continue;
+                }
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), error, { itemIndex });
+            }
+        }
+        return [returnData];
+    }
+}
+exports.AtomicMail = AtomicMail;
+//# sourceMappingURL=AtomicMail.node.js.map

--- a/dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js
+++ b/dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js
@@ -1,1 +1,136 @@
-../../../integrations/n8n/atomicmail/dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AtomicMailTrigger = void 0;
+const n8n_workflow_1 = require("n8n-workflow");
+const jmap_1 = require("../../lib/jmap");
+const session_1 = require("../../lib/session");
+const props_1 = require("../../lib/props");
+function extractEmails(body) {
+    if (!body || typeof body !== 'object')
+        return [];
+    const methodResponses = body.methodResponses;
+    if (!Array.isArray(methodResponses))
+        return [];
+    for (const entry of methodResponses) {
+        if (!Array.isArray(entry) || entry.length < 2)
+            continue;
+        const payload = entry[1];
+        if (payload &&
+            typeof payload === 'object' &&
+            Array.isArray(payload.list)) {
+            return payload.list;
+        }
+    }
+    return [];
+}
+function receivedMs(value) {
+    if (!value)
+        return 0;
+    const ms = Date.parse(value);
+    return Number.isFinite(ms) ? ms : 0;
+}
+class AtomicMailTrigger {
+    constructor() {
+        this.description = {
+            displayName: 'Atomic Mail Trigger',
+            name: 'atomicMailTrigger',
+            icon: {
+                light: 'file:../../icons/atomicmail.svg',
+                dark: 'file:../../icons/atomicmail.dark.svg',
+            },
+            group: ['trigger'],
+            version: 1,
+            subtitle: '={{$parameter["accountId"] || "default"}}',
+            description: 'Polls your Atomic Mail inbox on a schedule (default ~5 minutes) and starts the workflow when new mail arrives',
+            defaults: {
+                name: 'Atomic Mail Trigger',
+            },
+            inputs: [],
+            outputs: [n8n_workflow_1.NodeConnectionTypes.Main],
+            polling: true,
+            credentials: [
+                {
+                    name: 'atomicMailApi',
+                    required: false,
+                },
+            ],
+            properties: [
+                {
+                    displayName: 'Poll Interval (Minutes)',
+                    name: 'pollIntervalMinutes',
+                    type: 'number',
+                    default: 5,
+                    typeOptions: {
+                        minValue: 1,
+                        maxValue: 1440,
+                    },
+                    description: 'How often n8n should poll for new inbox messages when this workflow is active (default 5)',
+                },
+                {
+                    displayName: 'Account Namespace',
+                    name: 'accountId',
+                    type: 'string',
+                    default: 'default',
+                    description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes',
+                },
+                {
+                    displayName: 'API Key (Optional Override)',
+                    name: 'apiKey',
+                    type: 'string',
+                    typeOptions: { password: true },
+                    default: '',
+                    description: 'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
+                },
+            ],
+            usableAsTool: true,
+        };
+    }
+    async poll() {
+        const nodeStaticData = this.getWorkflowStaticData('node');
+        const credentialStaticData = this.getWorkflowStaticData('global');
+        let lastPollMs = nodeStaticData.lastPollMs;
+        if (typeof lastPollMs !== 'number' || !Number.isFinite(lastPollMs)) {
+            lastPollMs = Date.now();
+            nodeStaticData.lastPollMs = lastPollMs;
+        }
+        const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId'));
+        const inlineApiKey = this.getNodeParameter('apiKey', '');
+        const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
+        try {
+            const session = await (0, session_1.resolveSessionForExecute)(credentialStaticData, accountId, credentials, inlineApiKey, true);
+            const result = await (0, jmap_1.executePreset)(session, 'list_inbox.json');
+            if (!result.ok) {
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), result.message);
+            }
+            const emails = extractEmails(result.body);
+            const newLast = emails.reduce((acc, row) => Math.max(acc, receivedMs(row.receivedAt)), lastPollMs);
+            nodeStaticData.lastPollMs = newLast;
+            const fresh = emails
+                .filter((row) => receivedMs(row.receivedAt) > lastPollMs)
+                .map((row) => ({
+                id: row.id,
+                subject: row.subject,
+                from: row.from,
+                preview: row.preview,
+                receivedAt: row.receivedAt,
+            }));
+            if (fresh.length === 0) {
+                return null;
+            }
+            return [
+                fresh.map((row) => ({
+                    json: row,
+                })),
+            ];
+        }
+        catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if ((0, props_1.optionalTrimmedString)(inlineApiKey) || (credentials === null || credentials === void 0 ? void 0 : credentials.apiKey)) {
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), message);
+            }
+            throw new n8n_workflow_1.NodeOperationError(this.getNode(), `${message} Connect an API key credential, paste an API key, or run **Register** first.`);
+        }
+    }
+}
+exports.AtomicMailTrigger = AtomicMailTrigger;
+//# sourceMappingURL=AtomicMailTrigger.node.js.map

--- a/docs/n8n.md
+++ b/docs/n8n.md
@@ -91,15 +91,18 @@ Set **Account namespace** on every node to the same non-default value when runni
 npm run build:n8n          # refresh vendor/agentic-core
 cd integrations/n8n/atomicmail
 npm run build && npm run lint
+npm run sync:vetting-paths # copy entry files to repo root for Creator Portal
 npx @n8n/scan-community-package @atomicmail/n8n-nodes-atomicmail
 ```
 
-**Creator Portal vetting:** n8n resolves credential/node paths from the **repository root**, not `repository.directory`. The package declares official `dist/*.js` paths in `package.json`. Repo-root symlinks point at the package tree so vetting can find those files on GitHub:
+**Creator Portal vetting:** n8n resolves credential/node paths from the **repository root**, not `repository.directory`. GitHub raw URLs **do not follow symlinks** (they return the link target path as plain text), so repo-root copies are required — not symlinks:
 
-- `credentials/AtomicMailApi.credentials.ts` → `integrations/n8n/atomicmail/credentials/…`
-- `dist/credentials/*.js`, `dist/nodes/**/*.node.js` → matching paths under `integrations/n8n/atomicmail/dist/`
+- `credentials/AtomicMailApi.credentials.ts`
+- `dist/credentials/AtomicMailApi.credentials.js`
+- `dist/nodes/AtomicMail/AtomicMail.node.js`
+- `dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js`
 
-Only the three compiled entry files under `integrations/n8n/atomicmail/dist/` are committed (not the full `dist/` tree). After changing credentials or nodes, rebuild, refresh those three `.js` files if they changed, and verify root symlinks still resolve.
+After changing credentials or nodes: `npm run build`, then `npm run sync:vetting-paths`, and commit the package tree plus the four repo-root copies (only the three compiled entry files under `integrations/n8n/atomicmail/dist/`, not the full `dist/` tree).
 
 ## Release checklist
 

--- a/integrations/n8n/atomicmail/credentials/AtomicMailApi.credentials.ts
+++ b/integrations/n8n/atomicmail/credentials/AtomicMailApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { Icon, ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	Icon,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class AtomicMailApi implements ICredentialType {
 	name = 'atomicMailApi';
@@ -41,15 +46,15 @@ export class AtomicMailApi implements ICredentialType {
 		},
 	];
 
-	test = {
+	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{$credentials.apiUrl || "https://api.atomicmail.ai"}}',
 			url: '/.well-known/jmap',
-			method: 'GET' as const,
+			method: 'GET',
 		},
 		rules: [
 			{
-				type: 'responseCode' as const,
+				type: 'responseCode',
 				properties: {
 					value: 200,
 					message: 'Could not reach the Atomic Mail JMAP endpoint.',

--- a/integrations/n8n/atomicmail/package.json
+++ b/integrations/n8n/atomicmail/package.json
@@ -28,6 +28,7 @@
     "dev": "n8n-node dev",
     "lint": "n8n-node lint",
     "lint:fix": "n8n-node lint --fix",
+    "sync:vetting-paths": "node scripts/sync-vetting-paths.mjs",
     "release": "n8n-node release",
     "prepublishOnly": "n8n-node prerelease"
   },

--- a/integrations/n8n/atomicmail/scripts/sync-vetting-paths.mjs
+++ b/integrations/n8n/atomicmail/scripts/sync-vetting-paths.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Copy n8n credential/node entry files to repo-root paths expected by the
+ * Creator Portal vetting process (which reads GitHub raw content at the
+ * repository root and does not follow symlinks).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = path.resolve(packageDir, '../../..');
+
+const vettingPaths = [
+	'credentials/AtomicMailApi.credentials.ts',
+	'dist/credentials/AtomicMailApi.credentials.js',
+	'dist/nodes/AtomicMail/AtomicMail.node.js',
+	'dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js',
+];
+
+for (const relPath of vettingPaths) {
+	const src = path.join(packageDir, relPath);
+	const dest = path.join(repoRoot, relPath);
+
+	if (!fs.existsSync(src)) {
+		console.error(`Missing source file: ${src}`);
+		process.exit(1);
+	}
+
+	fs.mkdirSync(path.dirname(dest), { recursive: true });
+
+	if (fs.existsSync(dest)) {
+		const stat = fs.lstatSync(dest);
+		if (stat.isSymbolicLink()) {
+			fs.unlinkSync(dest);
+		}
+	}
+
+	fs.copyFileSync(src, dest);
+	console.log(`Synced ${relPath}`);
+}


### PR DESCRIPTION
Replace repo-root symlinks with real file copies because GitHub raw URLs return symlink targets as text, so vetting could not see the credential test.