### PR TITLE
Add UTM install-attribution to agent-skill CLI and MCP register

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -229,3 +229,29 @@ Full details: MCP `help` topic **`multi_account`**.
   }
 }
 ```
+
+## Install attribution (UTM)
+
+The MCP server is stdio-only, so there is no CLI flag — set `ATOMICMAIL_UTM` in
+the `env` block to tag where the install came from. A landing page templates
+this into the copy-paste `mcpServers` config:
+
+```json
+{
+  "mcpServers": {
+    "atomicmail": {
+      "command": "npx",
+      "args": ["-y", "@atomicmail/mcp"],
+      "env": {
+        "ATOMICMAIL_UTM": "utm_source=blog&utm_medium=cpc&utm_campaign=launch"
+      }
+    }
+  }
+}
+```
+
+The value is a URL-query-style string. Recognized keys are `utm_source`,
+`utm_medium`, `utm_campaign`, `utm_term`, and `utm_content`; anything else is
+ignored and each value is capped at 64 characters. Attribution is attached when
+the `register` tool creates a new account, never on API-key login, and never
+blocks registration.

--- a/docs/skill-install.md
+++ b/docs/skill-install.md
@@ -178,3 +178,23 @@ MCP `help` topic `multi_account` or [mcp.md](./mcp.md#multiple-accounts--agents)
   `ATOMIC_MAIL_API_URL`
 - Credentials path: `--credentials-dir` or `ATOMIC_MAIL_CREDENTIALS_DIR`
 - PoW salt: `--scrypt-salt` or `ATOMIC_MAIL_SCRYPT_SALT`
+- Install attribution: `--utm` or `ATOMICMAIL_UTM` (see below)
+
+## Install attribution (UTM)
+
+Optionally tag a `register` with where the install came from. Pass a
+URL-query-style string of `utm_*` fields on the `register` command:
+
+```bash
+npx --package=@atomicmail/agent-skill atomicmail register \
+  --username "myagent" \
+  --utm "utm_source=blog&utm_medium=cpc&utm_campaign=launch"
+```
+
+- Recognized keys: `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`,
+  `utm_content`. Anything else in the string is ignored; each value is capped at
+  64 characters.
+- The `--utm` flag takes precedence over the `ATOMICMAIL_UTM` environment
+  variable when both are set.
+- Attribution applies to new-account signup only (`--username`), not `--api-key`
+  login. It never blocks registration — a malformed value simply sends nothing.

--- a/ts/src/langchain/mod.test.ts
+++ b/ts/src/langchain/mod.test.ts
@@ -15,6 +15,7 @@ function makeContext(session: AgentSession) {
       capabilityFile: "/tmp/atomicmail/capability.jwt",
     },
     source: "defaults",
+    utm: {},
   };
   return { defaultConfig, defaultSession: session };
 }

--- a/ts/src/lib/agent/auth/agent-auth-http.test.ts
+++ b/ts/src/lib/agent/auth/agent-auth-http.test.ts
@@ -23,10 +23,12 @@ Deno.test("fetchChallenge reads challenge JWT from Authorization header", async 
   const challengeJWT = makeJwt({ jti: "abc", difficulty: 6 });
   try {
     globalThis.fetch = () =>
-      Promise.resolve(new Response("", {
-        status: 200,
-        headers: { Authorization: `Bearer ${challengeJWT}` },
-      }));
+      Promise.resolve(
+        new Response("", {
+          status: 200,
+          headers: { Authorization: `Bearer ${challengeJWT}` },
+        }),
+      );
 
     const challenge = await fetchChallenge("https://auth.example");
     assertEquals(challenge.challengeJWT, challengeJWT);
@@ -64,10 +66,12 @@ Deno.test("exchangeSession sends challenge JWT and reads session JWT from Author
           ? (JSON.parse(String(reqInit.body)) as Record<string, unknown>)
           : undefined,
       });
-      return Promise.resolve(new Response(JSON.stringify({ apiKey: "api-key" }), {
-        status: 200,
-        headers: { Authorization: "Bearer session-token" },
-      }));
+      return Promise.resolve(
+        new Response(JSON.stringify({ apiKey: "api-key" }), {
+          status: 200,
+          headers: { Authorization: "Bearer session-token" },
+        }),
+      );
     };
 
     const result = await exchangeSession("https://auth.example", {
@@ -90,6 +94,47 @@ Deno.test("exchangeSession sends challenge JWT and reads session JWT from Author
   }
 });
 
+Deno.test("exchangeSession includes only the present utm_* fields in the body", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ body?: Record<string, unknown> }> = [];
+  try {
+    globalThis.fetch = (_input, init) => {
+      const reqInit = init as RequestInit | undefined;
+      calls.push({
+        body: reqInit?.body
+          ? (JSON.parse(String(reqInit.body)) as Record<string, unknown>)
+          : undefined,
+      });
+      return Promise.resolve(
+        new Response(JSON.stringify({ apiKey: "api-key" }), {
+          status: 200,
+          headers: { Authorization: "Bearer session-token" },
+        }),
+      );
+    };
+
+    await exchangeSession("https://auth.example", {
+      challengeJWT: "challenge-token",
+      powHex: "deadbeef",
+      nonce: "42",
+      username: "agent",
+      utm_source: "blog",
+      utm_campaign: "launch",
+    });
+
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0].body, {
+      powHex: "deadbeef",
+      nonce: "42",
+      username: "agent",
+      utm_source: "blog",
+      utm_campaign: "launch",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 Deno.test("fetchCapability sends session JWT and reads capability JWT from Authorization header", async () => {
   const originalFetch = globalThis.fetch;
   const calls: Array<{ auth?: string }> = [];
@@ -100,10 +145,12 @@ Deno.test("fetchCapability sends session JWT and reads capability JWT from Autho
       calls.push({
         auth: headers.get("Authorization") ?? undefined,
       });
-      return Promise.resolve(new Response("", {
-        status: 200,
-        headers: { Authorization: "Bearer capability-token" },
-      }));
+      return Promise.resolve(
+        new Response("", {
+          status: 200,
+          headers: { Authorization: "Bearer capability-token" },
+        }),
+      );
     };
 
     const capability = await fetchCapability(

--- a/ts/src/lib/agent/auth/agent-auth-http.ts
+++ b/ts/src/lib/agent/auth/agent-auth-http.ts
@@ -2,6 +2,7 @@
 
 import { decodeJwtPayload } from "./agent-jwt.ts";
 import { solvePow } from "./agent-pow.ts";
+import type { UtmParams } from "./agent-utm.ts";
 
 export async function fetchChallenge(authUrl: string): Promise<{
   challengeJWT: string;
@@ -52,6 +53,12 @@ export async function exchangeSession(
     nonce: string;
     apiKey?: string;
     username?: string;
+    // UTM install-attribution (username signup only); present fields only.
+    utm_source?: string;
+    utm_medium?: string;
+    utm_campaign?: string;
+    utm_term?: string;
+    utm_content?: string;
   },
 ): Promise<SessionResponse> {
   const { challengeJWT, ...payload } = body;
@@ -65,7 +72,9 @@ export async function exchangeSession(
   });
   const text = await res.text();
   if (!res.ok) {
-    throw new Error(`auth-service /api/v1/session returned ${res.status}: ${text}`);
+    throw new Error(
+      `auth-service /api/v1/session returned ${res.status}: ${text}`,
+    );
   }
   const sessionJWT = readBearerToken(
     res.headers.get("Authorization"),
@@ -110,6 +119,8 @@ export interface PerformPoWInput {
   scryptSalt: string;
   apiKey?: string;
   username?: string;
+  /** Parsed UTM install-attribution; forwarded on the username signup path. */
+  utm?: UtmParams;
   onPowProgress?: (nonce: bigint) => void;
 }
 
@@ -130,6 +141,8 @@ export async function performPoWAndSession(
     nonce,
     apiKey: input.apiKey,
     username: input.username,
+    // Only present utm_* fields are spread in, so absent ones stay off the body.
+    ...(input.utm ?? {}),
   });
 }
 

--- a/ts/src/lib/agent/auth/agent-utm.test.ts
+++ b/ts/src/lib/agent/auth/agent-utm.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "@std/assert";
+
+import { hasUtm, parseUtm } from "./agent-utm.ts";
+
+Deno.test("parseUtm extracts the five known utm_* fields", () => {
+  const utm = parseUtm(
+    "utm_source=blog&utm_medium=cpc&utm_campaign=launch&utm_term=agents&utm_content=hero",
+  );
+  assertEquals(utm, {
+    utm_source: "blog",
+    utm_medium: "cpc",
+    utm_campaign: "launch",
+    utm_term: "agents",
+    utm_content: "hero",
+  });
+});
+
+Deno.test("parseUtm ignores non-utm keys and unknown params", () => {
+  const utm = parseUtm(
+    "utm_source=blog&ref=twitter&gclid=xyz&foo=bar&utm_campaign=launch",
+  );
+  assertEquals(utm, { utm_source: "blog", utm_campaign: "launch" });
+});
+
+Deno.test("parseUtm truncates over-long values to 64 chars", () => {
+  const long = "a".repeat(200);
+  const utm = parseUtm(`utm_campaign=${long}`);
+  assertEquals(utm.utm_campaign?.length, 64);
+  assertEquals(utm.utm_campaign, "a".repeat(64));
+});
+
+Deno.test("parseUtm drops empty values", () => {
+  assertEquals(parseUtm("utm_source=&utm_medium=cpc"), { utm_medium: "cpc" });
+});
+
+Deno.test("parseUtm returns no fields for empty / undefined / garbage input", () => {
+  assertEquals(parseUtm(""), {});
+  assertEquals(parseUtm(undefined), {});
+  assertEquals(parseUtm(null), {});
+  assertEquals(parseUtm("just some random text without pairs"), {});
+  assertEquals(parseUtm("source=blog&campaign=launch"), {});
+});
+
+Deno.test("parseUtm decodes URL-encoded values", () => {
+  const utm = parseUtm("utm_campaign=summer%20launch&utm_source=news%2Bletter");
+  assertEquals(utm.utm_campaign, "summer launch");
+  assertEquals(utm.utm_source, "news+letter");
+});
+
+Deno.test("hasUtm reflects whether any field is present", () => {
+  assertEquals(hasUtm({}), false);
+  assertEquals(hasUtm(undefined), false);
+  assertEquals(hasUtm({ utm_source: "blog" }), true);
+});

--- a/ts/src/lib/agent/auth/agent-utm.ts
+++ b/ts/src/lib/agent/auth/agent-utm.ts
@@ -1,0 +1,58 @@
+// UTM install-attribution parsing (shared by the CLI + MCP register paths).
+//
+// A landing page bakes a URL-query-style UTM string into the copy-paste install
+// snippet (CLI `--utm` flag / `ATOMICMAIL_UTM` env). On username signup the
+// parsed fields ride along in the auth-service session-exchange body and the
+// backend forwards them to PostHog. Parsing never throws: any problem yields an
+// empty object so registration never fails over UTM.
+
+/** The five UTM fields forwarded to the backend on username signup. */
+export interface UtmParams {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+}
+
+/** Known UTM keys, in wire order. Everything else in the string is ignored. */
+export const UTM_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+] as const;
+
+/** Backend caps each value at 64 chars; we truncate client-side to match. */
+export const UTM_MAX_VALUE_LENGTH = 64;
+
+/**
+ * Parse a URL-query-style UTM string (e.g.
+ * `utm_source=blog&utm_medium=cpc&utm_campaign=launch`) into the five known
+ * `utm_*` fields. Unknown keys are ignored, each value is truncated to 64
+ * chars, and empty values are dropped. Never throws — any parse problem (or an
+ * empty/garbage input) yields an empty object.
+ */
+export function parseUtm(raw: string | undefined | null): UtmParams {
+  if (!raw) return {};
+  try {
+    const params = new URLSearchParams(raw);
+    const out: UtmParams = {};
+    for (const key of UTM_KEYS) {
+      const value = params.get(key);
+      if (value === null) continue;
+      const truncated = value.slice(0, UTM_MAX_VALUE_LENGTH);
+      if (truncated.length === 0) continue;
+      out[key] = truncated;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** True when the parsed UTM object carries at least one field. */
+export function hasUtm(utm: UtmParams | undefined | null): utm is UtmParams {
+  return !!utm && Object.keys(utm).length > 0;
+}

--- a/ts/src/lib/agent/session/agent-resolve-config.ts
+++ b/ts/src/lib/agent/session/agent-resolve-config.ts
@@ -14,6 +14,7 @@ import {
   type SkillFiles,
   tryReadCredentials,
 } from "./agent-credentials-store.ts";
+import { parseUtm, type UtmParams } from "../auth/agent-utm.ts";
 
 export type ConfigSource =
   | "credentials-file"
@@ -30,6 +31,11 @@ export interface ResolvedAgentConfig {
   credentialDir: string;
   files: SkillFiles;
   source: ConfigSource;
+  /**
+   * Parsed UTM install-attribution from `ATOMICMAIL_UTM` (stdio-only MCP has no
+   * flag, so env is its only carrier). Empty object when unset/garbage.
+   */
+  utm: UtmParams;
 }
 
 /**
@@ -84,6 +90,7 @@ export async function resolveAgentConfigFromEnv(): Promise<
     DEFAULT_POW_SCRYPT_SALT_HEX;
   const apiKey = envApiKey ?? fileCreds?.apiKey;
   const inboxId = fileCreds?.inboxId;
+  const utm = parseUtm(env.ATOMICMAIL_UTM);
 
   const usingFile = fileCreds !== undefined;
   const usingEnv = !!(envAuthUrl || envApiUrl || envSalt || envApiKey);
@@ -104,5 +111,6 @@ export async function resolveAgentConfigFromEnv(): Promise<
     credentialDir,
     files,
     source,
+    utm,
   };
 }

--- a/ts/src/lib/agent/session/agent-session.ts
+++ b/ts/src/lib/agent/session/agent-session.ts
@@ -26,6 +26,7 @@ import {
   fetchCapability,
   performPoWAndSession,
 } from "../auth/agent-auth-http.ts";
+import type { UtmParams } from "../auth/agent-utm.ts";
 
 export interface AgentSessionConfig {
   authUrl: string;
@@ -52,6 +53,11 @@ export interface RegisterOptions {
    * requested username differs from the stored inbox local-part.
    */
   forced?: boolean;
+  /**
+   * Parsed UTM install-attribution, forwarded to the backend on first-time
+   * signup only (ignored on idempotent replay). Absent/empty is a no-op.
+   */
+  utm?: UtmParams;
 }
 
 function normalizeUsername(u: string): string {
@@ -288,6 +294,7 @@ export class AgentSession {
       authUrl: this.authUrl,
       scryptSalt: this.scryptSalt,
       username,
+      utm: options.utm,
     });
     if (!result.apiKey) {
       throw new Error(

--- a/ts/src/lib/mod.ts
+++ b/ts/src/lib/mod.ts
@@ -11,6 +11,7 @@ export * from "./agent/session/inbox-id-to-mailbox-email.ts";
 export * from "./agent/auth/agent-jwt.ts";
 export * from "./agent/auth/agent-pow.ts";
 export * from "./agent/auth/agent-auth-http.ts";
+export * from "./agent/auth/agent-utm.ts";
 export * from "./agent/jmap/agent-jmap.ts";
 export * from "./agent/jmap/agent-jmap-verify.ts";
 export * from "./agent/session/agent-session.ts";

--- a/ts/src/mcp/mcp-session-context.test.ts
+++ b/ts/src/mcp/mcp-session-context.test.ts
@@ -24,6 +24,7 @@ async function makeDefaultContext(
     credentialDir,
     files,
     source: "defaults" as const,
+    utm: {},
   };
   const defaultSession = await AgentSession.create({
     authUrl: defaultConfig.authUrl,
@@ -66,8 +67,12 @@ Deno.test(
 Deno.test(
   "resolveMcpToolSession creates ephemeral session for different credentials_dir",
   async () => {
-    const defaultDir = await Deno.makeTempDir({ prefix: "atomicmail-mcp-def-" });
-    const otherDir = await Deno.makeTempDir({ prefix: "atomicmail-mcp-other-" });
+    const defaultDir = await Deno.makeTempDir({
+      prefix: "atomicmail-mcp-def-",
+    });
+    const otherDir = await Deno.makeTempDir({
+      prefix: "atomicmail-mcp-other-",
+    });
     try {
       const ctx = await makeDefaultContext(defaultDir);
       const session = await resolveMcpToolSession(

--- a/ts/src/mcp/tools/jmap.test.ts
+++ b/ts/src/mcp/tools/jmap.test.ts
@@ -10,7 +10,9 @@ type ToolHandler = (
 
 interface CapturedTool {
   name: string;
-  config: { inputSchema: { safeParse: (value: unknown) => { success: boolean } } };
+  config: {
+    inputSchema: { safeParse: (value: unknown) => { success: boolean } };
+  };
   handler: ToolHandler;
 }
 
@@ -19,7 +21,9 @@ function makeCapturedJmapTool(ctx: McpSessionContext): CapturedTool {
   const fakeServer = {
     registerTool(
       name: string,
-      config: { inputSchema: { safeParse: (value: unknown) => { success: boolean } } },
+      config: {
+        inputSchema: { safeParse: (value: unknown) => { success: boolean } };
+      },
       handler: ToolHandler,
     ) {
       captured = { name, config, handler };
@@ -51,6 +55,7 @@ function makeContextWithSession(
       capabilityFile: "/tmp/atomicmail/capability.jwt",
     },
     source: "defaults",
+    utm: {},
   };
   return {
     defaultConfig,

--- a/ts/src/mcp/tools/register.ts
+++ b/ts/src/mcp/tools/register.ts
@@ -66,7 +66,12 @@ export function registerRegisterTool(
           credentials_dir,
           "register",
         );
-        const result = await session.register(username, { forced });
+        // UTM install-attribution rides in from ATOMICMAIL_UTM (stdio MCP has
+        // no CLI flag); applied on username signup only.
+        const result = await session.register(username, {
+          forced,
+          utm: ctx.defaultConfig.utm,
+        });
         return mcpText(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpError(

--- a/ts/src/skill/cli.ts
+++ b/ts/src/skill/cli.ts
@@ -13,6 +13,7 @@ import {
   expandCredentialDirInput,
   getHelp,
   parseUserVarsJson,
+  parseUtm,
   persistLoginWithApiKey,
   readCredentials,
   readOpsFile,
@@ -32,6 +33,7 @@ Commands:
 
 Examples:
   atomicmail register --username alice
+  atomicmail register --username alice --utm "utm_source=blog&utm_campaign=launch"
   atomicmail register --api-key UUID
   atomicmail jmap_request --ops-file list_inbox.json
   atomicmail jmap_request --credentials-dir ./.atomic-mail --ops-file send.json --vars '{"TO":"a@b.com","SUBJECT":"Hi"}'
@@ -67,6 +69,7 @@ async function cmdRegister(argv: string[]): Promise<void> {
         username: { type: "string" },
         "api-key": { type: "string" },
         "credentials-dir": { type: "string" },
+        utm: { type: "string" },
         forced: { type: "boolean" },
         quiet: { type: "boolean" },
         help: { type: "boolean", short: "h" },
@@ -90,6 +93,8 @@ Options:
   --username NAME      New account (5–21 characters; mutually exclusive with --api-key)
   --api-key KEY        Existing API key (mutually exclusive with --username)
   --credentials-dir DIR  Credential directory (default: ~/.atomicmail)
+  --utm STRING         Install-attribution, URL-query style (only with --username) [env: ATOMICMAIL_UTM]
+                       e.g. "utm_source=blog&utm_medium=cpc&utm_campaign=launch"
   --forced             Allow replacing existing credentials with a new account
   --quiet              Less stderr output
   --help, -h           This message
@@ -112,6 +117,12 @@ jmap_request alone.
     env.ATOMIC_MAIL_SCRYPT_SALT ?? DEFAULT_POW_SCRYPT_SALT_HEX;
   const dir = parsed.values["credentials-dir"] as string | undefined;
   const credentialDir = expandCredentialDirInput(dir);
+
+  // UTM install-attribution: --utm flag takes precedence over ATOMICMAIL_UTM.
+  // Parsing never throws, so a malformed value simply sends no utm fields.
+  const utm = parseUtm(
+    (parsed.values.utm as string | undefined) ?? env.ATOMICMAIL_UTM,
+  );
 
   const username = parsed.values.username as string | undefined;
   const apiKey = parsed.values["api-key"] as string | undefined;
@@ -138,6 +149,7 @@ jmap_request alone.
     });
     const result = await session.register(username, {
       forced: parsed.values.forced === true,
+      utm,
     });
     log(`Wrote credentials under ${credentialDir}`);
     process.stdout.write(JSON.stringify(result, null, 2) + "\n");


### PR DESCRIPTION
## What

A landing page bakes a URL-query-style UTM string into the copy-paste install snippet; on **username signup** the parsed fields ride along in the auth-service session-exchange body and the backend forwards them to PostHog (`user_registered`), so installs can be attributed to campaigns.

- **New shared `parseUtm` helper** (`ts/src/lib/agent/auth/agent-utm.ts`): extracts the five known `utm_*` keys, ignores everything else, truncates each to 64 chars, drops empties, **never throws** (any problem → `{}`).
- **agent-skill CLI**: `--utm` flag, falling back to `ATOMICMAIL_UTM` env (flag wins).
- **MCP** (stdio-only, no flags): `ATOMICMAIL_UTM` env, resolved into `ResolvedAgentConfig` and passed by the `register` tool.
- Threaded through `AgentSession.register → performPoWAndSession → exchangeSession` body, **username-signup path only** (never on apiKey login/renewal). Only present `utm_*` fields are sent.

## Wire contract (matches backend)

Optional `utm_source` / `utm_medium` / `utm_campaign` / `utm_term` / `utm_content` on the `POST /api/v1/session` body, each ≤64 chars. Backend PR: Atomic-Mail/agentic-mail#78.

## Tests

- `ts/src/lib/agent/auth/agent-utm.test.ts` — parse: valid → five fields, non-utm keys ignored, over-long → 64, empties dropped, garbage → `{}`, URL-decoding.
- `agent-auth-http.test.ts` — asserts present `utm_*` land in the `exchangeSession` body and absent ones don't.
- Full suite **82/82** with `--allow-sys` (the documented cmd omits `--allow-sys`, which pre-fails 6 unrelated homedir tests).

Docs updated: `docs/skill-install.md`, `docs/mcp.md`.

## Release note

No version field in-repo — version is injected at release time. Target release: **0.3.25** (both packages, shared version). Publishing before the backend reaches prod is safe (prod strips unknown `utm_*`); attribution starts recording once backend#78 ships to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)