### PR TITLE
fix(jmap): custom-domain $INBOX sender + JSON-safe multiline $VAR substitution

### DIFF
--- a/ts/src/lib/agent/jmap/agent-jmap-run.ts
+++ b/ts/src/lib/agent/jmap/agent-jmap-run.ts
@@ -1,7 +1,7 @@
 // JMAP execution for integration hosts (n8n bundle) — fetch-only, no node:fs.
 
 import { JMAP_NEXT_HINTS } from "../../core/jmap-hints.ts";
-import { inboxIdToMailboxEmail } from "../session/inbox-id-to-mailbox-email.ts";
+import { resolveInboxMailboxEmail } from "../session/inbox-id-to-mailbox-email.ts";
 import {
   assertBlobUploadEnvelopeWithinLimits,
   type JmapBlobUploadLimits,
@@ -187,6 +187,12 @@ export interface RunJmapRequestInput {
   sourceLabel: string;
   dryRun?: boolean;
   vars?: Record<string, string>;
+  /**
+   * `ATOMIC_MAIL_INBOX_DOMAIN` fallback for `$INBOX` when the inbox is stored as
+   * a bare local-part and the JMAP account id is not a real address. Integration
+   * hosts (no `process.env`) must pass this explicitly to override the default.
+   */
+  inboxDomain?: string;
 }
 
 export async function runJmapRequest(
@@ -200,20 +206,33 @@ export async function runJmapRequest(
     autoResolvers: {
       ACCOUNT_ID: () => input.session.getPrimaryMailAccountId(),
       INBOX: async () => {
-        const rawInbox = input.session.currentInboxId;
-        if (!rawInbox) {
+        const inboxId = input.session.currentInboxId;
+        // The JMAP primary mail accountId resolves to the inbox's REAL address
+        // (including custom domains), so prefer it over appending a domain.
+        let accountId: string | undefined;
+        try {
+          accountId = await input.session.getPrimaryMailAccountId();
+        } catch {
+          accountId = undefined;
+        }
+        const email = resolveInboxMailboxEmail({
+          inboxId,
+          accountId,
+          inboxDomain: input.inboxDomain,
+        });
+        if (!email) {
           throw new Error("No inbox in session; run register first.");
         }
-        return inboxIdToMailboxEmail(rawInbox);
+        return email;
       },
       INBOX_MAILBOX_ID: () => fetchInboxMailboxId(input.session),
-      UPLOAD_URL: async () => {
+      UPLOAD_URL: () => {
         if (input.session.currentUploadUrl) {
           return input.session.currentUploadUrl;
         }
         throw new Error("JMAP session missing uploadUrl.");
       },
-      DOWNLOAD_URL: async () => {
+      DOWNLOAD_URL: () => {
         if (input.session.currentDownloadUrl) {
           return input.session.currentDownloadUrl;
         }

--- a/ts/src/lib/agent/jmap/agent-jmap.ts
+++ b/ts/src/lib/agent/jmap/agent-jmap.ts
@@ -2,12 +2,12 @@
 
 import { readFile } from "node:fs/promises";
 import { dirname, isAbsolute, resolve as resolvePath } from "node:path";
-import { cwd } from "node:process";
+import { cwd, env } from "node:process";
 import { fileURLToPath } from "node:url";
 
 import { tryReadSharedJson } from "../../core/shared-assets.ts";
 import { readCredentials } from "../session/agent-credentials-store.ts";
-import { inboxIdToMailboxEmail } from "../session/inbox-id-to-mailbox-email.ts";
+import { resolveInboxMailboxEmail } from "../session/inbox-id-to-mailbox-email.ts";
 import {
   assertBlobUploadEnvelopeWithinLimits,
   type JmapBlobUploadLimits,
@@ -311,6 +311,12 @@ export interface RunJmapRequestInput {
   attachmentPathBase?: string;
   /** Values for `$VAR` tokens (keys without `$`). Overrides injected attachment vars. */
   vars?: Record<string, string>;
+  /**
+   * `ATOMIC_MAIL_INBOX_DOMAIN` fallback for `$INBOX` when the inbox is stored
+   * as a bare local-part and the JMAP account id is not a real address.
+   * Defaults to `process.env.ATOMIC_MAIL_INBOX_DOMAIN` when omitted.
+   */
+  inboxDomain?: string;
 }
 
 /**
@@ -342,15 +348,28 @@ export async function runJmapRequest(
     autoResolvers: {
       ACCOUNT_ID: () => input.session.getPrimaryMailAccountId(),
       INBOX: async () => {
-        const raw = input.session.currentInboxId ??
+        const inboxId = input.session.currentInboxId ??
           (input.session.files
             ? (await readCredentials(input.session.files.credentialsFile))
               .inboxId
             : undefined);
-        if (!raw) {
+        // The JMAP primary mail accountId resolves to the inbox's REAL address
+        // (including custom domains), so prefer it over appending a domain.
+        let accountId: string | undefined;
+        try {
+          accountId = await input.session.getPrimaryMailAccountId();
+        } catch {
+          accountId = undefined;
+        }
+        const email = resolveInboxMailboxEmail({
+          inboxId,
+          accountId,
+          inboxDomain: input.inboxDomain ?? env.ATOMIC_MAIL_INBOX_DOMAIN,
+        });
+        if (!email) {
           throw new Error("No inbox in session; run register first.");
         }
-        return inboxIdToMailboxEmail(raw);
+        return email;
       },
       INBOX_MAILBOX_ID: () => fetchInboxMailboxId(input.session),
       UPLOAD_URL: async () => {

--- a/ts/src/lib/agent/jmap/agent-vars.test.ts
+++ b/ts/src/lib/agent/jmap/agent-vars.test.ts
@@ -1,0 +1,72 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+import { substituteResolvedVars, substituteVars } from "./agent-vars.ts";
+
+/** The real bundled preset that places `$BODY` inside a JSON string literal. */
+const SEND_MAIL_PRESET = Deno.readTextFileSync(
+  new URL("../../../../../shared/presets/send_mail.json", import.meta.url),
+);
+
+Deno.test("substituteVars: multiline $BODY into send_mail.json stays valid JSON", async () => {
+  // Bug 2: a body with newlines/quotes/backslashes/tabs used to splice raw text
+  // into a JSON string literal and break JSON.parse ("Bad control character").
+  const body = 'Line 1\nLine 2\twith tab\nHe said "hi" and a path C:\\temp\\x';
+  const { text } = await substituteVars({
+    raw: SEND_MAIL_PRESET,
+    vars: {
+      ACCOUNT_ID: "acct-1",
+      INBOX_MAILBOX_ID: "mbox-1",
+      INBOX: "sasha@cdtest.atomicmail.ai",
+      TO: "dest@example.com",
+      SUBJECT: "Hi there",
+      BODY: body,
+    },
+  });
+
+  // Must parse without throwing, and the body must round-trip exactly.
+  const parsed = JSON.parse(text) as {
+    methodCalls: [string, Record<string, unknown>, string][];
+  };
+  const emailSet = parsed.methodCalls[0][1] as {
+    create: { d1: { bodyValues: { b: { value: string } } } };
+  };
+  assertEquals(emailSet.create.d1.bodyValues.b.value, body);
+});
+
+Deno.test("substituteResolvedVars: escapes control chars inside JSON strings", () => {
+  const raw = '{"value":"$BODY"}';
+  const resolved = new Map([["BODY", 'a\nb"c\\d\te']]);
+  const out = substituteResolvedVars(raw, resolved);
+  const parsed = JSON.parse(out) as { value: string };
+  assertEquals(parsed.value, 'a\nb"c\\d\te');
+});
+
+Deno.test("substituteResolvedVars: bare (non-string) tokens substitute verbatim", () => {
+  // Outside a string literal the value is inserted raw, preserving numeric /
+  // structural placeholders (e.g. a user-supplied inline limit).
+  const raw = '{"limit":$LIMIT}';
+  const resolved = new Map([["LIMIT", "50"]]);
+  const out = substituteResolvedVars(raw, resolved);
+  const parsed = JSON.parse(out) as { limit: number };
+  assertEquals(parsed.limit, 50);
+});
+
+Deno.test("substituteResolvedVars: leaves lowercase JMAP keywords untouched", () => {
+  // `$draft` is a JMAP keyword, not a user var — VAR pattern requires uppercase.
+  const raw = '{"keywords":{"$draft":true},"from":"$INBOX"}';
+  const resolved = new Map([["INBOX", "sasha@cdtest.atomicmail.ai"]]);
+  const out = substituteResolvedVars(raw, resolved);
+  assertStringIncludes(out, '"$draft":true');
+  const parsed = JSON.parse(out) as { from: string };
+  assertEquals(parsed.from, "sasha@cdtest.atomicmail.ai");
+});
+
+Deno.test("substituteVars: value containing another $TOKEN is not rescanned", async () => {
+  const { text } = await substituteVars({
+    raw: '{"a":"$A","b":"$B"}',
+    vars: { A: "$B", B: "second" },
+  });
+  const parsed = JSON.parse(text) as { a: string; b: string };
+  assertEquals(parsed.a, "$B");
+  assertEquals(parsed.b, "second");
+});

--- a/ts/src/lib/agent/jmap/agent-vars.ts
+++ b/ts/src/lib/agent/jmap/agent-vars.ts
@@ -87,9 +87,80 @@ function formatMissingError(missing: string[]): Error {
   return new Error(msg);
 }
 
+const VAR_START_RE = /[A-Z]/;
+const VAR_CHAR_RE = /[A-Z0-9_]/;
+
 /**
- * Replaces every `$VAR_NAME` in `raw` with the corresponding string.
- * Single pass — values are not scanned for further `$` tokens.
+ * Replaces every `$VAR_NAME` in `raw` with its resolved value, JSON-context
+ * aware: when a token sits inside a JSON string literal the value is escaped
+ * for string context (so newlines, quotes, backslashes, tabs, and other control
+ * characters round-trip and never break `JSON.parse`); bare tokens (outside a
+ * string) are substituted verbatim, preserving numeric/structural placeholders.
+ *
+ * Single pass over the original text — resolved values are not rescanned for
+ * further `$` tokens.
+ */
+export function substituteResolvedVars(
+  raw: string,
+  resolved: Map<string, string>,
+): string {
+  let out = "";
+  let inString = false;
+  let i = 0;
+  const n = raw.length;
+
+  while (i < n) {
+    const ch = raw[i]!;
+
+    if (inString) {
+      // Copy escape pairs verbatim so an escaped quote doesn't close the string
+      // and a `$` after a backslash stays correctly positioned.
+      if (ch === "\\") {
+        out += ch;
+        if (i + 1 < n) {
+          out += raw[i + 1];
+          i += 2;
+          continue;
+        }
+        i += 1;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+        out += ch;
+        i += 1;
+        continue;
+      }
+    } else if (ch === '"') {
+      inString = true;
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === "$" && i + 1 < n && VAR_START_RE.test(raw[i + 1]!)) {
+      let j = i + 1;
+      while (j < n && VAR_CHAR_RE.test(raw[j]!)) j += 1;
+      const name = raw.slice(i + 1, j);
+      if (resolved.has(name)) {
+        const value = resolved.get(name)!;
+        // In string context, escape for a JSON string interior (strip the outer
+        // quotes JSON.stringify adds); bare context keeps the raw value.
+        out += inString ? JSON.stringify(value).slice(1, -1) : value;
+        i = j;
+        continue;
+      }
+    }
+
+    out += ch;
+    i += 1;
+  }
+
+  return out;
+}
+
+/**
+ * Resolves every `$VAR_NAME` referenced in `raw` and substitutes it JSON-safely.
  * Throws if any referenced variable has no value (after vars + autoResolvers).
  */
 export async function substituteVars(
@@ -120,9 +191,5 @@ export async function substituteVars(
     throw formatMissingError(missing);
   }
 
-  const text = input.raw.replace(varPattern(), (_full, name: string) => {
-    return resolved.get(name)!;
-  });
-
-  return { text };
+  return { text: substituteResolvedVars(input.raw, resolved) };
 }

--- a/ts/src/lib/agent/session/inbox-id-to-mailbox-email.test.ts
+++ b/ts/src/lib/agent/session/inbox-id-to-mailbox-email.test.ts
@@ -1,6 +1,10 @@
 import { assertEquals } from "@std/assert";
 
-import { inboxIdToMailboxEmail } from "./inbox-id-to-mailbox-email.ts";
+import {
+  inboxIdToMailboxEmail,
+  looksLikeEmailAddress,
+  resolveInboxMailboxEmail,
+} from "./inbox-id-to-mailbox-email.ts";
 
 Deno.test("inboxIdToMailboxEmail leaves full addresses unchanged", () => {
   assertEquals(inboxIdToMailboxEmail("agent@example.com"), "agent@example.com");
@@ -21,4 +25,80 @@ Deno.test("inboxIdToMailboxEmail respects ATOMIC_MAIL_INBOX_DOMAIN", () => {
     }),
     "bob@other.example",
   );
+});
+
+Deno.test("looksLikeEmailAddress accepts real addresses, rejects opaque ids", () => {
+  assertEquals(looksLikeEmailAddress("sasha@cdtest.atomicmail.ai"), true);
+  assertEquals(looksLikeEmailAddress("alice@atomicmail.ai"), true);
+  // Opaque JMAP account ids (no dotted domain / no @) must NOT be treated as
+  // addresses, so resolution falls back to domain-append.
+  assertEquals(looksLikeEmailAddress("u_12345"), false);
+  assertEquals(looksLikeEmailAddress("account@1"), false);
+  assertEquals(looksLikeEmailAddress("a@b@c.com"), false);
+});
+
+Deno.test("resolveInboxMailboxEmail derives custom-domain $INBOX from accountId", () => {
+  // Bug 1: credentials persist only the local-part ("sasha"); the JMAP account
+  // id carries the REAL custom-domain address. $INBOX must use it, not the
+  // hardcoded @atomicmail.ai.
+  assertEquals(
+    resolveInboxMailboxEmail({
+      inboxId: "sasha",
+      accountId: "sasha@cdtest.atomicmail.ai",
+    }),
+    "sasha@cdtest.atomicmail.ai",
+  );
+});
+
+Deno.test("resolveInboxMailboxEmail uses accountId when no inboxId is known", () => {
+  assertEquals(
+    resolveInboxMailboxEmail({ accountId: "agent@corp.example" }),
+    "agent@corp.example",
+  );
+});
+
+Deno.test("resolveInboxMailboxEmail honors ATOMIC_MAIL_INBOX_DOMAIN fallback", () => {
+  // No usable accountId → the env override must take effect at request time.
+  assertEquals(
+    resolveInboxMailboxEmail({
+      inboxId: "sasha",
+      accountId: "opaque-account-id",
+      inboxDomain: "cdtest.atomicmail.ai",
+    }),
+    "sasha@cdtest.atomicmail.ai",
+  );
+});
+
+Deno.test("resolveInboxMailboxEmail defaults to atomicmail.ai when nothing else", () => {
+  assertEquals(
+    resolveInboxMailboxEmail({ inboxId: "alice" }),
+    "alice@atomicmail.ai",
+  );
+});
+
+Deno.test("resolveInboxMailboxEmail keeps a stored full address verbatim", () => {
+  assertEquals(
+    resolveInboxMailboxEmail({
+      inboxId: "alice@stored.example",
+      accountId: "alice@other.example",
+    }),
+    "alice@stored.example",
+  );
+});
+
+Deno.test("resolveInboxMailboxEmail ignores accountId whose local-part mismatches", () => {
+  // Guard against an unexpected account id swapping the sender: fall back to
+  // domain-append on the known inbox local-part instead.
+  assertEquals(
+    resolveInboxMailboxEmail({
+      inboxId: "sasha",
+      accountId: "someoneelse@cdtest.atomicmail.ai",
+      inboxDomain: "cdtest.atomicmail.ai",
+    }),
+    "sasha@cdtest.atomicmail.ai",
+  );
+});
+
+Deno.test("resolveInboxMailboxEmail returns empty when nothing is known", () => {
+  assertEquals(resolveInboxMailboxEmail({}), "");
 });

--- a/ts/src/lib/agent/session/inbox-id-to-mailbox-email.ts
+++ b/ts/src/lib/agent/session/inbox-id-to-mailbox-email.ts
@@ -26,3 +26,74 @@ export function inboxIdToMailboxEmail(
 
   return `${trimmed}@${domain}`;
 }
+
+/** Local-part of an email address (lowercased), or "" when malformed. */
+function emailLocalPart(email: string): string {
+  const at = email.indexOf("@");
+  return at > 0 ? email.slice(0, at).trim().toLowerCase() : "";
+}
+
+/**
+ * True when `s` has a plausible `local@domain` shape (single `@`, non-empty
+ * local part, dotted domain). Used to decide whether a JMAP `accountId` is a
+ * real mailbox address rather than an opaque account id.
+ */
+export function looksLikeEmailAddress(s: string): boolean {
+  const trimmed = s.trim();
+  const parts = trimmed.split("@");
+  if (parts.length !== 2) return false;
+  const [local, domain] = parts;
+  return local.length > 0 && domain.length > 0 && domain.includes(".");
+}
+
+export interface ResolveInboxMailboxEmailInput {
+  /** Stored inbox local-part (e.g. `sasha`) or full address, if known. */
+  inboxId?: string;
+  /**
+   * JMAP primary mail `accountId`. In this system it resolves to the inbox's
+   * REAL address (e.g. `sasha@cdtest.atomicmail.ai`), so it is the
+   * authoritative source for `$INBOX` on custom domains.
+   */
+  accountId?: string;
+  /** `ATOMIC_MAIL_INBOX_DOMAIN` fallback for local-part-only inbox ids. */
+  inboxDomain?: string;
+}
+
+/**
+ * Resolves the `$INBOX` mailbox address, preferring the inbox's real address.
+ *
+ * Priority:
+ *   1. `inboxId` already a full address (`local@domain`) — use verbatim.
+ *   2. JMAP `accountId` that looks like an email whose local-part matches the
+ *      stored `inboxId` (or when no `inboxId` is known) — the real address,
+ *      which is correct for custom domains with zero extra config.
+ *   3. `inboxId` + `ATOMIC_MAIL_INBOX_DOMAIN` (secondary fallback).
+ *   4. `inboxId` + the default `atomicmail.ai` domain.
+ *
+ * Returns `""` when nothing usable is available (caller should error).
+ */
+export function resolveInboxMailboxEmail(
+  input: ResolveInboxMailboxEmailInput,
+): string {
+  const inboxId = input.inboxId?.trim();
+  const accountId = input.accountId?.trim();
+
+  // 1. Stored full address wins (explicitly persisted with a domain).
+  if (inboxId && inboxId.includes("@")) return inboxId;
+
+  // 2. Real address from the JMAP session account id.
+  if (accountId && looksLikeEmailAddress(accountId)) {
+    if (!inboxId || emailLocalPart(accountId) === inboxId.toLowerCase()) {
+      return accountId;
+    }
+  }
+
+  // 3 + 4. Append configured / default domain to the local-part.
+  if (inboxId && inboxId.length > 0) {
+    return inboxIdToMailboxEmail(inboxId, {
+      ATOMIC_MAIL_INBOX_DOMAIN: input.inboxDomain,
+    });
+  }
+
+  return "";
+}


### PR DESCRIPTION
Fixes two client-side bugs surfaced during the custom-domains prod E2E (both in `ts/src/lib`, the dnt build source for `@atomicmail/agent-skill` + `@atomicmail/mcp`).

## 1. Custom-domain sender (`$INBOX` hardcoded `@atomicmail.ai`)
Sending from a custom-domain inbox failed: `$INBOX` was built as `<inboxId>@atomicmail.ai`, so the backend rejected it with `forbiddenFrom` ("Only @cdtest.atomicmail.ai is allowed"). `credentials.json` stores only `inboxId`, and the `ATOMIC_MAIL_INBOX_DOMAIN` override wasn't threaded through.

**Fix:** new `resolveInboxMailboxEmail` derives `$INBOX` from the JMAP session — in this system the primary-mail `accountId` resolves to the inbox's real address (e.g. `sasha@cdtest.atomicmail.ai`). Priority: stored full address → `accountId` (with local-part match) → `inboxId` + `ATOMIC_MAIL_INBOX_DOMAIN` → `inboxId` + default domain. Works for custom domains with zero extra config; wired into the `$INBOX` autoResolver in `agent-jmap-run.ts` / `agent-jmap.ts`.

## 2. Multiline / control chars in `$VAR` substitution broke JSON
A `SUBJECT`/`BODY` with newlines (or quotes/backslashes/tabs) was spliced raw into the envelope JSON text, producing `Bad control character in string literal` on `JSON.parse`.

**Fix:** `substituteResolvedVars` is now JSON-context-aware — a token inside a string literal is escaped for string context (`JSON.stringify(v).slice(1,-1)`), bare tokens substitute verbatim (preserving numeric/structural placeholders). Escape pairs are tracked so an escaped quote doesn't close the string.

## Tests
16 new/updated unit tests across `inbox-id-to-mailbox-email.test.ts` and `agent-vars.test.ts`; full `src/lib/agent` suite **50 passed, 0 failed**. fmt + lint clean.

## Notes
- Source-only fix in `ts/src/lib`; the published packages are regenerated from it at build (`build_skill_npm.ts` via `@deno/dnt`).
- The remote MCP server (`agentic-mail/services/mcp-server`) had the same multiline bug — fixed separately in agentic-mail PR #82. Its custom-domain `$INBOX` was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)