### PR TITLE
docs: use --watch scheduled in register examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ hermes skills install clawhub/atomicmail
 ### 💻 AgentSkill
 
 ```bash
-npx --package=@atomicmail/agent-skill-github atomicmail register --username "myagent" --watch on-demand
+npx --package=@atomicmail/agent-skill-github atomicmail register --username "myagent" --watch scheduled
 npx --package=@atomicmail/agent-skill-github atomicmail jmap_request --ops-file list_inbox.json
 npx --package=@atomicmail/agent-skill-github atomicmail help
 ```

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -26,7 +26,7 @@ package.
 ## Commands
 
 ```bash
-npx --package=@atomicmail/agent-skill-gh-pages atomicmail register --username "myagent" --watch on-demand
+npx --package=@atomicmail/agent-skill-gh-pages atomicmail register --username "myagent" --watch scheduled
 
 npx --package=@atomicmail/agent-skill-gh-pages atomicmail jmap_request --ops-file list_inbox.json
 ```
@@ -46,7 +46,7 @@ Run **`atomicmail --help`** or **`atomicmail <command> --help`** for flags.
 ```bash
 npx --package=@atomicmail/agent-skill-gh-pages atomicmail register \
   --username "alice" \
-  --watch on-demand
+  --watch scheduled
 ```
 
 `--watch` is **required** — it is your operator's decision, not yours; ask them.

--- a/docs/custom-domains.md
+++ b/docs/custom-domains.md
@@ -42,7 +42,7 @@ registration step and no username to choose.
 **Local MCP / AgentSkill** — log in with the inbox's API key:
 
 ```bash
-atomicmail register --api-key "..." --watch on-demand
+atomicmail register --api-key "..." --watch scheduled
 ```
 
 Or set it in the environment and let the client pick it up:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ writes JSON somewhere and tells nobody. Full detail: `help` topic `cron`.
 MCP hosts pass it on the tool call; the CLI takes `--watch`:
 
 ```bash
-atomicmail register --username "myagent" --watch on-demand
+atomicmail register --username "myagent" --watch scheduled
 ```
 
 ## Ideal agent flow
@@ -98,7 +98,7 @@ Then call tools in this order: `register` -> `jmap_request` -> `help`. The
 `register` call needs both a `username` and a `watch` value:
 
 ```json
-{ "username": "myagent", "watch": "on-demand" }
+{ "username": "myagent", "watch": "scheduled" }
 ```
 
 
@@ -107,7 +107,7 @@ Continue with full docs: [`MCP in-depth`](/mcp).
 ## Install for shell-capable agents (AgentSkill)
 
 ```bash
-npx --package=@atomicmail/agent-skill-gh-pages atomicmail register --username "myagent" --watch on-demand
+npx --package=@atomicmail/agent-skill-gh-pages atomicmail register --username "myagent" --watch scheduled
 npx --package=@atomicmail/agent-skill-gh-pages atomicmail jmap_request --ops-file list_inbox.json
 npx --package=@atomicmail/agent-skill-gh-pages atomicmail help
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -78,7 +78,7 @@ For ClawHub, use the MCP-only channel package:
    existing `credentials.json`):
 
    ```json
-   { "username": "myagent", "watch": "on-demand" }
+   { "username": "myagent", "watch": "scheduled" }
    ```
 
    Omit `watch` and the call comes back with the requirement rather than an

--- a/docs/skill-install.md
+++ b/docs/skill-install.md
@@ -34,7 +34,7 @@ npx --package=@atomicmail/agent-skill-gh-pages atomicmail --help
 ```bash
 npx --package=@atomicmail/agent-skill-gh-pages atomicmail register \
   --username "myagent" \
-  --watch on-demand
+  --watch scheduled
 
 npx --package=@atomicmail/agent-skill-gh-pages atomicmail jmap_request \
   --ops '[["Mailbox/get", {"accountId": "$ACCOUNT_ID"}, "m0"]]'

--- a/shared/skill/SKILL.template.md
+++ b/shared/skill/SKILL.template.md
@@ -40,7 +40,7 @@ Run **`atomicmail --help`** or **`atomicmail <command> --help`** for flags.
 ```bash
 {{ATOMICMAIL_CLI}} register \
   --username "alice" \
-  --watch on-demand
+  --watch scheduled
 ```
 
 `--watch` is **required** — it is your operator's decision, not yours; ask them.


### PR DESCRIPTION
## What

Switches the copy-paste **register** examples from `--watch on-demand` to `--watch scheduled` — 10 command examples (CLI + MCP JSON) across 7 files.

## Why

The quickstart examples hardcoded `--watch on-demand`, which:
- buried the scheduled inbox-check flow (the whole point of `watch`), and
- modeled a de-facto default, even though the docs explicitly state `watch` has **no** default and the operator must choose (see `shared/messages/errors.json`, `shared/help/topics/cron.md`).

## Scope

Changed (examples only):
- `README.md`
- `docs/getting-started.md` (CLI + MCP JSON)
- `docs/SKILL.md`
- `docs/mcp.md`
- `docs/skill-install.md`
- `docs/custom-domains.md`
- `shared/skill/SKILL.template.md`

**Left unchanged on purpose:** reference tables/descriptions that define both values, the cron/error help text, and the `WatchValue = "scheduled" | "on-demand"` union — `on-demand` remains a valid, documented choice. `ts/skill_npm/` is git-ignored build output and regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)