### PR TITLE
n8n node: OAuth 2.0 auth (0.4.0)

### DIFF
--- a/dist/credentials/AtomicMailOAuth2Api.credentials.js
+++ b/dist/credentials/AtomicMailOAuth2Api.credentials.js
@@ -1,0 +1,88 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AtomicMailOAuth2Api = void 0;
+class AtomicMailOAuth2Api {
+    constructor() {
+        this.name = 'atomicMailOAuth2Api';
+        this.extends = ['oAuth2Api'];
+        this.displayName = 'Atomic Mail OAuth2 API';
+        this.icon = {
+            light: 'file:../icons/atomicmail.svg',
+            dark: 'file:../icons/atomicmail.dark.svg',
+        };
+        this.documentationUrl = 'https://github.com/Atomic-Mail/atomic-mail-agentic/blob/develop/docs/n8n.md';
+        this.properties = [
+            {
+                displayName: 'Grant Type',
+                name: 'grantType',
+                type: 'hidden',
+                default: 'pkce',
+            },
+            {
+                displayName: 'Authorization URL',
+                name: 'authUrl',
+                type: 'hidden',
+                default: 'https://auth.atomicmail.ai/oauth/authorize',
+            },
+            {
+                displayName: 'Access Token URL',
+                name: 'accessTokenUrl',
+                type: 'hidden',
+                default: 'https://auth.atomicmail.ai/oauth/token',
+            },
+            {
+                displayName: 'Client ID',
+                name: 'clientId',
+                type: 'string',
+                default: 'urn:atomicmail:client:dyn:81e0d57f-59f6-42f6-9074-9efc7c9f82fa',
+                required: true,
+                description: 'Public OAuth client ID. n8n Cloud works with the shipped default. Self-hosted: register your own with POST https://auth.atomicmail.ai/oauth/register (RFC 7591), listing this credential\'s OAuth callback URL in redirect_uris.',
+            },
+            {
+                displayName: 'Client Secret',
+                name: 'clientSecret',
+                type: 'hidden',
+                typeOptions: { password: true },
+                default: '',
+            },
+            {
+                displayName: 'Scope',
+                name: 'scope',
+                type: 'options',
+                options: [
+                    {
+                        name: 'Read Only (mail.read)',
+                        value: 'mail.read',
+                    },
+                    {
+                        name: 'Read and Send (mail.read mail.send)',
+                        value: 'mail.read mail.send',
+                    },
+                ],
+                default: 'mail.read',
+                description: 'Sending requires mail.send. The consent screen may still narrow the grant to read-only; a read-only connection gets a clear insufficient_scope error on send.',
+            },
+            {
+                displayName: 'Auth URI Query Parameters',
+                name: 'authQueryParameters',
+                type: 'hidden',
+                default: 'resource=https%3A%2F%2Fapi.atomicmail.ai%2Fjmap',
+            },
+            {
+                displayName: 'Authentication',
+                name: 'authentication',
+                type: 'hidden',
+                default: 'body',
+            },
+        ];
+        this.test = {
+            request: {
+                baseURL: 'https://auth.atomicmail.ai',
+                url: '/api/v1/agents',
+                method: 'GET',
+            },
+        };
+    }
+}
+exports.AtomicMailOAuth2Api = AtomicMailOAuth2Api;
+//# sourceMappingURL=AtomicMailOAuth2Api.credentials.js.map

--- a/dist/nodes/AtomicMail/AtomicMail.node.js
+++ b/dist/nodes/AtomicMail/AtomicMail.node.js
@@ -5,6 +5,7 @@ const n8n_workflow_1 = require("n8n-workflow");
 const index_js_1 = require("../../vendor/agentic-core/index.js");
 const attachments_1 = require("../../lib/attachments");
 const jmap_1 = require("../../lib/jmap");
+const oauth_1 = require("../../lib/oauth");
 const session_1 = require("../../lib/session");
 const props_1 = require("../../lib/props");
 function unwrapJmapResult(context, itemIndex, result) {
@@ -34,11 +35,43 @@ class AtomicMail {
             usableAsTool: true,
             credentials: [
                 {
+                    name: 'atomicMailOAuth2Api',
+                    required: false,
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                    },
+                },
+                {
                     name: 'atomicMailApi',
                     required: false,
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
             ],
             properties: [
+                {
+                    displayName: 'Authentication',
+                    name: 'authentication',
+                    type: 'options',
+                    noDataExpression: true,
+                    options: [
+                        {
+                            name: 'API Key (Legacy)',
+                            value: 'apiKey',
+                            description: 'Agent-owned inbox via the proof-of-work path',
+                        },
+                        {
+                            name: 'OAuth2 (Recommended)',
+                            value: 'oAuth2',
+                            description: 'A person signs in once and authorizes n8n — no proof of work',
+                        },
+                    ],
+                    default: 'oAuth2',
+                    displayOptions: {
+                        hide: { resource: ['help'] },
+                    },
+                },
                 {
                     displayName: 'Resource',
                     name: 'resource',
@@ -115,12 +148,27 @@ class AtomicMail {
                     default: 'get',
                 },
                 {
+                    displayName: 'Inbox Name or ID',
+                    name: 'inbox',
+                    type: 'options',
+                    typeOptions: {
+                        loadOptionsMethod: 'getInboxes',
+                    },
+                    default: '',
+                    description: 'Which inbox to act as. Leave empty to auto-select when the connection has exactly one inbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                        hide: { resource: ['account', 'help'] },
+                    },
+                },
+                {
                     displayName: 'Account Namespace',
                     name: 'accountId',
                     type: 'string',
                     default: 'default',
                     description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes in this workflow',
                     displayOptions: {
+                        show: { authentication: ['apiKey'] },
                         hide: { resource: ['help'] },
                     },
                 },
@@ -132,6 +180,7 @@ class AtomicMail {
                     default: '',
                     description: 'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
                     displayOptions: {
+                        show: { authentication: ['apiKey'] },
                         hide: { resource: ['account', 'help'] },
                     },
                 },
@@ -302,9 +351,20 @@ class AtomicMail {
                 },
             ],
         };
+        this.methods = {
+            loadOptions: {
+                async getInboxes() {
+                    const inboxes = await (0, oauth_1.listOAuthInboxes)(this);
+                    return inboxes.map((inbox) => ({
+                        name: inbox.inboxId ? `${inbox.inboxId} (${inbox.accountId})` : inbox.accountId,
+                        value: inbox.accountId,
+                    }));
+                },
+            },
+        };
     }
     async execute() {
-        var _a, _b, _c, _d;
+        var _a, _b, _c, _d, _e;
         const items = this.getInputData();
         const returnData = [];
         for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
@@ -321,8 +381,120 @@ class AtomicMail {
                     });
                     continue;
                 }
-                const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', itemIndex));
                 const itemJson = (_a = items[itemIndex]) === null || _a === void 0 ? void 0 : _a.json;
+                const authentication = this.getNodeParameter('authentication', itemIndex, 'oAuth2');
+                if (authentication === 'oAuth2' && (await (0, oauth_1.hasOAuthCredential)(this))) {
+                    if (resource === 'account') {
+                        throw new n8n_workflow_1.NodeOperationError(this.getNode(), 'Register applies to the legacy API-key (proof-of-work) path. With OAuth the inbox is created when you connect the Atomic Mail OAuth2 credential — switch Authentication to "API Key (Legacy)" to use Register.', { itemIndex });
+                    }
+                    const oauthAccountId = await (0, oauth_1.resolveOAuthAccountId)(this, this.getNodeParameter('inbox', itemIndex, ''));
+                    const inboxContext = await (0, oauth_1.ensureOAuthInboxContext)(this, staticData, oauthAccountId);
+                    if (resource === 'inbox' && operation === 'list') {
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.listInboxBody)(inboxContext.mailboxId)));
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    if (resource === 'email' && operation === 'send') {
+                        const to = (0, props_1.requiredString)(this.getNodeParameter('to', itemIndex), 'to');
+                        const subject = (0, props_1.requiredString)(this.getNodeParameter('subject', itemIndex), 'subject');
+                        const body = (0, props_1.requiredString)(this.getNodeParameter('body', itemIndex), 'body');
+                        const binaryProperty = (0, props_1.optionalTrimmedString)(this.getNodeParameter('binaryProperty', itemIndex, ''));
+                        if (binaryProperty) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), 'Binary attachments are not yet supported on the OAuth path. Switch Authentication to "API Key (Legacy)" to send attachments.', { itemIndex });
+                        }
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.sendMailBody)({ context: inboxContext, to, subject, body })));
+                        const setError = (0, oauth_1.jmapSetErrorMessage)(result.body);
+                        if (setError) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), setError, { itemIndex });
+                        }
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    if (resource === 'email' && operation === 'reply') {
+                        const mailId = (0, props_1.requiredString)(this.getNodeParameter('mailId', itemIndex), 'mailId');
+                        const body = (0, props_1.requiredString)(this.getNodeParameter('body', itemIndex), 'body');
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.replyBody)({ context: inboxContext, mailId, body })));
+                        const setError = (0, oauth_1.jmapSetErrorMessage)(result.body);
+                        if (setError) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), setError, { itemIndex });
+                        }
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    if (resource === 'jmap' && operation === 'request') {
+                        const requestSource = this.getNodeParameter('requestSource', itemIndex, 'preset');
+                        const dryRun = this.getNodeParameter('dryRun', itemIndex, false);
+                        if (dryRun) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), 'Dry run is only supported with the API-key (legacy) credential.', { itemIndex });
+                        }
+                        const parsedVars = (0, jmap_1.parseVarsJson)(this.getNodeParameter('vars', itemIndex, ''));
+                        if (!parsedVars.ok) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), parsedVars.message, { itemIndex });
+                        }
+                        let opsJson;
+                        if (requestSource === 'inline') {
+                            const opsParam = this.getNodeParameter('ops', itemIndex, '');
+                            opsJson =
+                                typeof opsParam === 'string'
+                                    ? (0, props_1.optionalTrimmedString)(opsParam)
+                                    : opsParam && typeof opsParam === 'object'
+                                        ? JSON.stringify(opsParam)
+                                        : undefined;
+                            if (!opsJson) {
+                                throw new n8n_workflow_1.NodeOperationError(this.getNode(), (0, index_js_1.sharedError)('mcp_ops_required'), {
+                                    itemIndex,
+                                });
+                            }
+                        }
+                        else {
+                            const opsFile = (0, props_1.requiredString)(this.getNodeParameter('opsFile', itemIndex, ''), 'opsFile');
+                            opsJson = await (0, index_js_1.readOpsFile)('n8n://oauth', opsFile);
+                        }
+                        const substituted = (0, oauth_1.substituteOpsVars)(opsJson, {
+                            ACCOUNT_ID: oauthAccountId,
+                            INBOX: inboxContext.address,
+                            INBOX_MAILBOX_ID: inboxContext.mailboxId,
+                            ...((_b = parsedVars.vars) !== null && _b !== void 0 ? _b : {}),
+                        });
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.opsJsonToBody)(substituted)));
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    throw new n8n_workflow_1.NodeOperationError(this.getNode(), `Unsupported operation ${resource}/${operation}.`, { itemIndex });
+                }
+                const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', itemIndex, 'default'));
                 const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
                 const inlineApiKey = this.getNodeParameter('apiKey', itemIndex, '');
                 if (resource === 'account' && operation === 'ensureRegistered') {
@@ -335,7 +507,7 @@ class AtomicMail {
                                 ...(0, session_1.authPassthrough)(itemJson),
                                 skipped: true,
                                 idempotent: true,
-                                inbox: (_c = (_b = stored === null || stored === void 0 ? void 0 : stored.inbox) !== null && _b !== void 0 ? _b : session.currentInboxId) !== null && _c !== void 0 ? _c : '',
+                                inbox: (_d = (_c = stored === null || stored === void 0 ? void 0 : stored.inbox) !== null && _c !== void 0 ? _c : session.currentInboxId) !== null && _d !== void 0 ? _d : '',
                                 accountId: accountIdResolved,
                                 ...((stored === null || stored === void 0 ? void 0 : stored.apiKey) ? { apiKey: stored.apiKey } : {}),
                             },
@@ -399,7 +571,7 @@ class AtomicMail {
                         TO: to,
                         SUBJECT: subject,
                         BODY: body,
-                        ...((_d = attachmentResult.vars) !== null && _d !== void 0 ? _d : {}),
+                        ...((_e = attachmentResult.vars) !== null && _e !== void 0 ? _e : {}),
                     };
                     const result = unwrapJmapResult(this, itemIndex, await (0, jmap_1.executePreset)(session, attachmentResult.vars
                         ? 'send_mail_blob_attachment.json'

--- a/dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js
+++ b/dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.AtomicMailTrigger = void 0;
 const n8n_workflow_1 = require("n8n-workflow");
 const jmap_1 = require("../../lib/jmap");
+const oauth_1 = require("../../lib/oauth");
 const session_1 = require("../../lib/session");
 const props_1 = require("../../lib/props");
 function extractEmails(body) {
@@ -50,11 +51,52 @@ class AtomicMailTrigger {
             polling: true,
             credentials: [
                 {
+                    name: 'atomicMailOAuth2Api',
+                    required: false,
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                    },
+                },
+                {
                     name: 'atomicMailApi',
                     required: false,
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
             ],
             properties: [
+                {
+                    displayName: 'Authentication',
+                    name: 'authentication',
+                    type: 'options',
+                    options: [
+                        {
+                            name: 'API Key (Legacy)',
+                            value: 'apiKey',
+                            description: 'Agent-owned inbox via the proof-of-work path',
+                        },
+                        {
+                            name: 'OAuth2 (Recommended)',
+                            value: 'oAuth2',
+                            description: 'A person signs in once and authorizes n8n — no proof of work',
+                        },
+                    ],
+                    default: 'oAuth2',
+                },
+                {
+                    displayName: 'Inbox Name or ID',
+                    name: 'inbox',
+                    type: 'options',
+                    typeOptions: {
+                        loadOptionsMethod: 'getInboxes',
+                    },
+                    default: '',
+                    description: 'Which inbox to poll. Leave empty to auto-select when the connection has exactly one inbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                    },
+                },
                 {
                     displayName: 'Poll Interval (Minutes)',
                     name: 'pollIntervalMinutes',
@@ -72,6 +114,9 @@ class AtomicMailTrigger {
                     type: 'string',
                     default: 'default',
                     description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes',
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
                 {
                     displayName: 'API Key (Optional Override)',
@@ -80,9 +125,23 @@ class AtomicMailTrigger {
                     typeOptions: { password: true },
                     default: '',
                     description: 'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
             ],
             usableAsTool: true,
+        };
+        this.methods = {
+            loadOptions: {
+                async getInboxes() {
+                    const inboxes = await (0, oauth_1.listOAuthInboxes)(this);
+                    return inboxes.map((inbox) => ({
+                        name: inbox.inboxId ? `${inbox.inboxId} (${inbox.accountId})` : inbox.accountId,
+                        value: inbox.accountId,
+                    }));
+                },
+            },
         };
     }
     async poll() {
@@ -93,43 +152,59 @@ class AtomicMailTrigger {
             lastPollMs = Date.now();
             nodeStaticData.lastPollMs = lastPollMs;
         }
-        const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId'));
-        const inlineApiKey = this.getNodeParameter('apiKey', '');
-        const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
-        try {
-            const session = await (0, session_1.resolveSessionForExecute)(credentialStaticData, accountId, credentials, inlineApiKey, true);
-            const result = await (0, jmap_1.executePreset)(session, 'list_inbox.json');
+        const authentication = this.getNodeParameter('authentication', 'oAuth2');
+        const useOAuth = authentication === 'oAuth2' && (await (0, oauth_1.hasOAuthCredential)(this));
+        let emails;
+        if (useOAuth) {
+            const accountId = await (0, oauth_1.resolveOAuthAccountId)(this, this.getNodeParameter('inbox', '')).catch((error) => {
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), error.message);
+            });
+            const inboxContext = await (0, oauth_1.ensureOAuthInboxContext)(this, credentialStaticData, accountId);
+            const result = await (0, oauth_1.jmapViaOAuth)(this, accountId, (0, oauth_1.listInboxBody)(inboxContext.mailboxId));
             if (!result.ok) {
                 throw new n8n_workflow_1.NodeOperationError(this.getNode(), result.message);
             }
-            const emails = extractEmails(result.body);
-            const newLast = emails.reduce((acc, row) => Math.max(acc, receivedMs(row.receivedAt)), lastPollMs);
-            nodeStaticData.lastPollMs = newLast;
-            const fresh = emails
-                .filter((row) => receivedMs(row.receivedAt) > lastPollMs)
-                .map((row) => ({
-                id: row.id,
-                subject: row.subject,
-                from: row.from,
-                preview: row.preview,
-                receivedAt: row.receivedAt,
-            }));
-            if (fresh.length === 0) {
-                return null;
-            }
-            return [
-                fresh.map((row) => ({
-                    json: row,
-                })),
-            ];
+            emails = extractEmails(result.body);
         }
-        catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            if ((0, props_1.optionalTrimmedString)(inlineApiKey) || (credentials === null || credentials === void 0 ? void 0 : credentials.apiKey)) {
-                throw new n8n_workflow_1.NodeOperationError(this.getNode(), message);
+        else {
+            const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', 'default'));
+            const inlineApiKey = this.getNodeParameter('apiKey', '');
+            const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
+            try {
+                const session = await (0, session_1.resolveSessionForExecute)(credentialStaticData, accountId, credentials, inlineApiKey, true);
+                const result = await (0, jmap_1.executePreset)(session, 'list_inbox.json');
+                if (!result.ok) {
+                    throw new n8n_workflow_1.NodeOperationError(this.getNode(), result.message);
+                }
+                emails = extractEmails(result.body);
             }
-            throw new n8n_workflow_1.NodeOperationError(this.getNode(), `${message} Connect an API key credential, paste an API key, or run **Register** first.`);
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                if ((0, props_1.optionalTrimmedString)(inlineApiKey) || (credentials === null || credentials === void 0 ? void 0 : credentials.apiKey)) {
+                    throw new n8n_workflow_1.NodeOperationError(this.getNode(), message);
+                }
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), `${message} Connect the Atomic Mail OAuth2 credential (recommended), connect an API key credential, paste an API key, or run **Register** first.`);
+            }
         }
+        const newLast = emails.reduce((acc, row) => Math.max(acc, receivedMs(row.receivedAt)), lastPollMs);
+        nodeStaticData.lastPollMs = newLast;
+        const fresh = emails
+            .filter((row) => receivedMs(row.receivedAt) > lastPollMs)
+            .map((row) => ({
+            id: row.id,
+            subject: row.subject,
+            from: row.from,
+            preview: row.preview,
+            receivedAt: row.receivedAt,
+        }));
+        if (fresh.length === 0) {
+            return null;
+        }
+        return [
+            fresh.map((row) => ({
+                json: row,
+            })),
+        ];
     }
 }
 exports.AtomicMailTrigger = AtomicMailTrigger;

--- a/docs/n8n.md
+++ b/docs/n8n.md
@@ -8,9 +8,68 @@ Install the community node `@atomicmail/n8n-nodes-atomicmail` to give n8n workfl
 
 ## Auth model
 
-The n8n node uses the **proof-of-work** path — the workflow owns its inbox, no human sign-in, no OAuth. Either run the **Register** action once (PoW signup, credentials stored in workflow-global static data) or paste an existing API key into an **Atomic Mail API** credential. Details in [Credentials](#credentials) below; the underlying HTTP chain is [REST authentication](/rest-auth).
+Since **0.4.0** the node supports two authentication paths, selected by the
+**Authentication** parameter on each node:
 
-If you would rather a **person** own the mailbox and authorize n8n against it, use n8n's generic HTTP Request node with an OAuth 2.0 credential pointed at [our authorization server](/oauth) — the settings are the same ones listed on the [Make.com page](/make#connection-settings), including the mandatory `resource` parameter and the `X-Atomic-Account-Id` header.
+- **OAuth2 (recommended, the default)** — a person signs in once at
+  [our authorization server](/oauth) and authorizes n8n against the inboxes
+  they own. No proof of work runs on the n8n worker: the node sends the OAuth
+  access token directly as the JMAP bearer and n8n refreshes it (rotating
+  refresh token) itself. This is the right choice on **n8n Cloud**, where the
+  PoW handshake cannot reliably finish inside the challenge TTL on shared CPU.
+  Setup in [Connect with OAuth](#connect-with-oauth) below.
+- **API Key (legacy)** — the original **proof-of-work** path: the workflow owns
+  its inbox, no human sign-in. Either run the **Register** action once (PoW
+  signup, credentials stored in workflow-global static data) or paste an
+  existing API key into an **Atomic Mail API** credential. Details in
+  [Credentials](#credentials) below; the underlying HTTP chain is
+  [REST authentication](/rest-auth). Prefer this only for agent-owned inboxes
+  on self-hosted n8n with real CPU.
+
+Workflows saved before 0.4.0 keep working unchanged: when no OAuth credential
+is connected, the node automatically stays on the legacy path.
+
+## Connect with OAuth {#connect-with-oauth}
+
+1. Create an **Atomic Mail OAuth2 API** credential in n8n.
+2. Enter your **Client ID**. Until a shared public client is published, register
+   your own — the client is **public** (no secret), via
+   [dynamic client registration](/oauth#getting-a-client-id):
+
+   ```bash
+   curl -X POST https://auth.atomicmail.ai/oauth/register \
+     -H "Content-Type: application/json" \
+     -d '{
+       "client_name": "n8n",
+       "redirect_uris": ["<the OAuth callback URL n8n shows on the credential>"],
+       "token_endpoint_auth_method": "none",
+       "grant_types": ["authorization_code", "refresh_token"],
+       "response_types": ["code"]
+     }'
+   ```
+
+   The callback URL is `https://oauth.n8n.cloud/oauth2/callback` on n8n Cloud
+   and `<your n8n host>/rest/oauth2-credential/callback` self-hosted — copy it
+   verbatim from the credential dialog; it is matched by exact string equality.
+3. Pick the **Scope** — *Read Only* (`mail.read`, default) or *Read and Send*
+   (`mail.read mail.send`). Sending on a read-only connection returns a clear
+   `insufficient_scope` error. The consent screen may narrow the grant to
+   read-only even when send was requested.
+4. Click **Connect my account** and sign in (Google/GitHub); pick or create the
+   inbox at the consent screen.
+5. On the node, choose **Authentication → OAuth2** (the default), then pick the
+   **Inbox** from the dropdown (populated from `GET /api/v1/agents`). With
+   exactly one inbox on the connection you can leave it empty — it is
+   auto-selected at runtime.
+
+Under the hood the flow is authorization code + **PKCE `S256`** with the
+mandatory `resource=https://api.atomicmail.ai/jmap` parameter, and every JMAP
+call carries the required `X-Atomic-Account-Id` header — the same contract as
+the [Make.com connector](/make#connection-settings).
+
+**OAuth-path limitations** (use the legacy path for these, for now): the
+**Register** operation (with OAuth the inbox is created at the consent screen
+instead), binary attachments on **Send**, and JMAP **Dry Run**.
 
 ## Install
 
@@ -55,9 +114,11 @@ To make Register faster on macOS:
 
 Monitor during Register: `docker stats n8n-demo` — one CPU near 100% confirms CPU-bound PoW.
 
-## Credentials {#credentials}
+## Credentials (legacy API-key path) {#credentials}
 
-The **Atomic Mail API** credential is optional:
+The **Atomic Mail API** credential is optional and applies to the legacy
+**API Key** authentication path only (for OAuth see
+[Connect with OAuth](#connect-with-oauth) above):
 
 - **API Key** — paste an existing Atomic Mail API key, or leave empty and use **Register**.
 - **Auth URL** — default `https://auth.atomicmail.ai`
@@ -93,7 +154,7 @@ After **Register**, read the `_next` hint in the output and arrange inbox pollin
 
 On first activation, the trigger seeds a watermark so existing mail is not replayed. Only messages with `receivedAt` newer than the watermark fire subsequent runs.
 
-Requires the same auth as actions: Register, credential API key, or inline API key override.
+Requires the same auth as actions: the OAuth2 credential (recommended), or on the legacy path Register, credential API key, or inline API key override. On the OAuth path a poll is a single JMAP `POST` with the access token as bearer — zero `/api/v1/challenge` calls and no scrypt on the worker.
 
 ## Presets and JMAP
 

--- a/docs/n8n.md
+++ b/docs/n8n.md
@@ -32,8 +32,13 @@ is connected, the node automatically stays on the legacy path.
 ## Connect with OAuth {#connect-with-oauth}
 
 1. Create an **Atomic Mail OAuth2 API** credential in n8n.
-2. Enter your **Client ID**. Until a shared public client is published, register
-   your own — the client is **public** (no secret), via
+2. **Client ID** — on **n8n Cloud** the credential works out of the box: it ships
+   with a public client whose redirect is n8n Cloud's shared callback
+   `https://oauth.n8n.cloud/oauth2/callback` (leave the field as-is). **Self-hosted**
+   users replace it with their own public client, because each self-hosted instance
+   has a distinct callback URL (`<your n8n host>/rest/oauth2-credential/callback`,
+   matched by exact string equality) that must be registered on the client. Copy
+   that callback verbatim from the credential dialog and register via
    [dynamic client registration](/oauth#getting-a-client-id):
 
    ```bash
@@ -41,16 +46,14 @@ is connected, the node automatically stays on the legacy path.
      -H "Content-Type: application/json" \
      -d '{
        "client_name": "n8n",
-       "redirect_uris": ["<the OAuth callback URL n8n shows on the credential>"],
+       "redirect_uris": ["<your n8n host>/rest/oauth2-credential/callback"],
        "token_endpoint_auth_method": "none",
        "grant_types": ["authorization_code", "refresh_token"],
        "response_types": ["code"]
      }'
    ```
 
-   The callback URL is `https://oauth.n8n.cloud/oauth2/callback` on n8n Cloud
-   and `<your n8n host>/rest/oauth2-credential/callback` self-hosted — copy it
-   verbatim from the credential dialog; it is matched by exact string equality.
+   Then paste the returned `client_id` into the credential's **Client ID** field.
 3. Pick the **Scope** — *Read Only* (`mail.read`, default) or *Read and Send*
    (`mail.read mail.send`). Sending on a read-only connection returns a clear
    `insufficient_scope` error. The consent screen may narrow the grant to

--- a/integrations/n8n/atomicmail/.gitignore
+++ b/integrations/n8n/atomicmail/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 dist/**
 !dist/credentials/
 !dist/credentials/AtomicMailApi.credentials.js
+!dist/credentials/AtomicMailOAuth2Api.credentials.js
 !dist/nodes/
 !dist/nodes/AtomicMail/
 !dist/nodes/AtomicMail/AtomicMail.node.js

--- a/integrations/n8n/atomicmail/CHANGELOG.md
+++ b/integrations/n8n/atomicmail/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## 0.4.0
+
+- **OAuth 2.0 authentication** (new default): both nodes gained an
+  **Authentication** selector with a new **Atomic Mail OAuth2 API** credential
+  (authorization code + PKCE `S256`, public client, rotating refresh token
+  handled by n8n). JMAP calls send the OAuth access token directly as the
+  bearer plus the mandatory `X-Atomic-Account-Id` header — no proof-of-work,
+  no `/api/v1/challenge` calls, no scrypt on the n8n worker.
+- New **Inbox** parameter (dropdown fed by `GET /api/v1/agents`);
+  auto-selected at runtime when the connection has exactly one inbox.
+- The **API Key** credential and the proof-of-work path remain supported as
+  **API Key (Legacy)** for existing workflows; workflows saved before this
+  version keep working unchanged (automatic fallback when no OAuth credential
+  is connected).
+- OAuth-path limitations (use the legacy path for now): **Register** (the
+  inbox is created at the OAuth consent screen instead), binary attachments,
+  and JMAP dry run.
+
+## 0.3.23 and earlier
+
+See git history.

--- a/integrations/n8n/atomicmail/README.md
+++ b/integrations/n8n/atomicmail/README.md
@@ -30,6 +30,19 @@ Or install the built package into n8n's custom nodes directory.
 
 ## Credentials
 
+### Atomic Mail OAuth2 API (recommended)
+
+OAuth 2.0 authorization code + PKCE `S256` against `https://auth.atomicmail.ai`
+— a public client, no secret. A person signs in once and authorizes n8n; n8n
+refreshes the access token (rotating refresh token) itself and the node uses it
+directly as the JMAP bearer with the mandatory `X-Atomic-Account-Id` header.
+No proof of work runs on the n8n worker. Register a `client_id` via RFC 7591
+dynamic client registration (`POST https://auth.atomicmail.ai/oauth/register`)
+with the credential's OAuth callback URL in `redirect_uris` — see the
+[monorepo n8n guide](../../../docs/n8n.md) for the exact steps.
+
+### Atomic Mail API (legacy, proof-of-work path)
+
 Create an **Atomic Mail API** credential (optional):
 
 | Field | Required | Notes |
@@ -61,10 +74,10 @@ Polling trigger for new inbox messages. Default poll interval is **5 minutes** (
 
 ## Auth paths
 
-Both paths are supported (Activepieces parity):
+Select with the **Authentication** parameter on each node:
 
-1. **Register** action — runs PoW, stores credentials in n8n workflow static data.
-2. **Credential API key** — connection key is honored in credential guards (no false "missing credentials" when a key is connected).
+1. **OAuth2 (default, recommended)** — human-owned inbox, access token as JMAP bearer, no PoW. Workflows saved before 0.4.0 (no OAuth credential connected) automatically stay on the legacy path.
+2. **API Key (legacy)** — the PoW path: **Register** action (stores credentials in n8n workflow static data) or a **Credential API key** (honored in credential guards — no false "missing credentials" when a key is connected).
 
 Optional per-step **API Key override** accepts expressions such as `{{ $json.apiKey }}` from a prior Register node.
 

--- a/integrations/n8n/atomicmail/README.md
+++ b/integrations/n8n/atomicmail/README.md
@@ -36,9 +36,12 @@ OAuth 2.0 authorization code + PKCE `S256` against `https://auth.atomicmail.ai`
 — a public client, no secret. A person signs in once and authorizes n8n; n8n
 refreshes the access token (rotating refresh token) itself and the node uses it
 directly as the JMAP bearer with the mandatory `X-Atomic-Account-Id` header.
-No proof of work runs on the n8n worker. Register a `client_id` via RFC 7591
-dynamic client registration (`POST https://auth.atomicmail.ai/oauth/register`)
-with the credential's OAuth callback URL in `redirect_uris` — see the
+No proof of work runs on the n8n worker. On **n8n Cloud** the credential ships
+with a public `client_id` and works out of the box (the shared callback
+`https://oauth.n8n.cloud/oauth2/callback` is registered on it). **Self-hosted**
+users register their own `client_id` via RFC 7591 dynamic client registration
+(`POST https://auth.atomicmail.ai/oauth/register`) with their instance's OAuth
+callback URL in `redirect_uris` — see the
 [monorepo n8n guide](../../../docs/n8n.md) for the exact steps.
 
 ### Atomic Mail API (legacy, proof-of-work path)

--- a/integrations/n8n/atomicmail/credentials/AtomicMailOAuth2Api.credentials.ts
+++ b/integrations/n8n/atomicmail/credentials/AtomicMailOAuth2Api.credentials.ts
@@ -46,16 +46,18 @@ export class AtomicMailOAuth2Api implements ICredentialType {
 			default: 'https://auth.atomicmail.ai/oauth/token',
 		},
 		{
-			// TODO: replace the empty default with the published public client_id
-			// once one is registered for n8n (see PR description). Until then users
-			// register their own via RFC 7591 dynamic client registration.
+			// Public client for n8n Cloud (redirect https://oauth.n8n.cloud/oauth2/callback),
+			// registered via RFC 7591 dynamic client registration and validated live
+			// end-to-end on n8n Cloud. Self-hosted users override this with their own
+			// client registered for their instance's callback URL (see docs/n8n.md) —
+			// each host has a distinct redirect_uri that must be registered on the client.
 			displayName: 'Client ID',
 			name: 'clientId',
 			type: 'string',
-			default: '',
+			default: 'urn:atomicmail:client:dyn:81e0d57f-59f6-42f6-9074-9efc7c9f82fa',
 			required: true,
 			description:
-				'Public OAuth client ID. Register one with POST https://auth.atomicmail.ai/oauth/register (RFC 7591), listing this credential\'s OAuth callback URL in redirect_uris.',
+				'Public OAuth client ID. n8n Cloud works with the shipped default. Self-hosted: register your own with POST https://auth.atomicmail.ai/oauth/register (RFC 7591), listing this credential\'s OAuth callback URL in redirect_uris.',
 		},
 		{
 			// Public client — the auth server accepts token_endpoint_auth_method

--- a/integrations/n8n/atomicmail/credentials/AtomicMailOAuth2Api.credentials.ts
+++ b/integrations/n8n/atomicmail/credentials/AtomicMailOAuth2Api.credentials.ts
@@ -1,0 +1,111 @@
+import type {
+	Icon,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+/**
+ * OAuth 2.0 authorization-code + PKCE (S256) against auth.atomicmail.ai.
+ * Public client — no client secret. n8n's `pkce` grant type generates the
+ * verifier/S256 challenge and rotates the refresh token automatically.
+ * The access token is used directly as the JMAP bearer (see docs/oauth.md).
+ */
+export class AtomicMailOAuth2Api implements ICredentialType {
+	name = 'atomicMailOAuth2Api';
+
+	extends = ['oAuth2Api'];
+
+	displayName = 'Atomic Mail OAuth2 API';
+
+	icon: Icon = {
+		light: 'file:../icons/atomicmail.svg',
+		dark: 'file:../icons/atomicmail.dark.svg',
+	};
+
+	documentationUrl =
+		'https://github.com/Atomic-Mail/atomic-mail-agentic/blob/develop/docs/n8n.md';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'hidden',
+			default: 'pkce',
+		},
+		{
+			displayName: 'Authorization URL',
+			name: 'authUrl',
+			type: 'hidden',
+			default: 'https://auth.atomicmail.ai/oauth/authorize',
+		},
+		{
+			displayName: 'Access Token URL',
+			name: 'accessTokenUrl',
+			type: 'hidden',
+			default: 'https://auth.atomicmail.ai/oauth/token',
+		},
+		{
+			// TODO: replace the empty default with the published public client_id
+			// once one is registered for n8n (see PR description). Until then users
+			// register their own via RFC 7591 dynamic client registration.
+			displayName: 'Client ID',
+			name: 'clientId',
+			type: 'string',
+			default: '',
+			required: true,
+			description:
+				'Public OAuth client ID. Register one with POST https://auth.atomicmail.ai/oauth/register (RFC 7591), listing this credential\'s OAuth callback URL in redirect_uris.',
+		},
+		{
+			// Public client — the auth server accepts token_endpoint_auth_method
+			// "none"; no secret exists.
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'hidden',
+			typeOptions: { password: true },
+			default: '',
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'options',
+			options: [
+				{
+					name: 'Read Only (mail.read)',
+					value: 'mail.read',
+				},
+				{
+					name: 'Read and Send (mail.read mail.send)',
+					value: 'mail.read mail.send',
+				},
+			],
+			default: 'mail.read',
+			description:
+				'Sending requires mail.send. The consent screen may still narrow the grant to read-only; a read-only connection gets a clear insufficient_scope error on send.',
+		},
+		{
+			// `resource` (RFC 8707) must match https://api.atomicmail.ai/jmap byte
+			// for byte after URL-decoding; n8n appends this string to the authorize
+			// URL as-is, so it is pre-encoded here.
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
+			type: 'hidden',
+			default: 'resource=https%3A%2F%2Fapi.atomicmail.ai%2Fjmap',
+		},
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden',
+			default: 'body',
+		},
+	];
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: 'https://auth.atomicmail.ai',
+			url: '/api/v1/agents',
+			method: 'GET',
+		},
+	};
+}

--- a/integrations/n8n/atomicmail/dist/credentials/AtomicMailOAuth2Api.credentials.js
+++ b/integrations/n8n/atomicmail/dist/credentials/AtomicMailOAuth2Api.credentials.js
@@ -34,9 +34,9 @@ class AtomicMailOAuth2Api {
                 displayName: 'Client ID',
                 name: 'clientId',
                 type: 'string',
-                default: '',
+                default: 'urn:atomicmail:client:dyn:81e0d57f-59f6-42f6-9074-9efc7c9f82fa',
                 required: true,
-                description: 'Public OAuth client ID. Register one with POST https://auth.atomicmail.ai/oauth/register (RFC 7591), listing this credential\'s OAuth callback URL in redirect_uris.',
+                description: 'Public OAuth client ID. n8n Cloud works with the shipped default. Self-hosted: register your own with POST https://auth.atomicmail.ai/oauth/register (RFC 7591), listing this credential\'s OAuth callback URL in redirect_uris.',
             },
             {
                 displayName: 'Client Secret',

--- a/integrations/n8n/atomicmail/dist/credentials/AtomicMailOAuth2Api.credentials.js
+++ b/integrations/n8n/atomicmail/dist/credentials/AtomicMailOAuth2Api.credentials.js
@@ -1,0 +1,88 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AtomicMailOAuth2Api = void 0;
+class AtomicMailOAuth2Api {
+    constructor() {
+        this.name = 'atomicMailOAuth2Api';
+        this.extends = ['oAuth2Api'];
+        this.displayName = 'Atomic Mail OAuth2 API';
+        this.icon = {
+            light: 'file:../icons/atomicmail.svg',
+            dark: 'file:../icons/atomicmail.dark.svg',
+        };
+        this.documentationUrl = 'https://github.com/Atomic-Mail/atomic-mail-agentic/blob/develop/docs/n8n.md';
+        this.properties = [
+            {
+                displayName: 'Grant Type',
+                name: 'grantType',
+                type: 'hidden',
+                default: 'pkce',
+            },
+            {
+                displayName: 'Authorization URL',
+                name: 'authUrl',
+                type: 'hidden',
+                default: 'https://auth.atomicmail.ai/oauth/authorize',
+            },
+            {
+                displayName: 'Access Token URL',
+                name: 'accessTokenUrl',
+                type: 'hidden',
+                default: 'https://auth.atomicmail.ai/oauth/token',
+            },
+            {
+                displayName: 'Client ID',
+                name: 'clientId',
+                type: 'string',
+                default: '',
+                required: true,
+                description: 'Public OAuth client ID. Register one with POST https://auth.atomicmail.ai/oauth/register (RFC 7591), listing this credential\'s OAuth callback URL in redirect_uris.',
+            },
+            {
+                displayName: 'Client Secret',
+                name: 'clientSecret',
+                type: 'hidden',
+                typeOptions: { password: true },
+                default: '',
+            },
+            {
+                displayName: 'Scope',
+                name: 'scope',
+                type: 'options',
+                options: [
+                    {
+                        name: 'Read Only (mail.read)',
+                        value: 'mail.read',
+                    },
+                    {
+                        name: 'Read and Send (mail.read mail.send)',
+                        value: 'mail.read mail.send',
+                    },
+                ],
+                default: 'mail.read',
+                description: 'Sending requires mail.send. The consent screen may still narrow the grant to read-only; a read-only connection gets a clear insufficient_scope error on send.',
+            },
+            {
+                displayName: 'Auth URI Query Parameters',
+                name: 'authQueryParameters',
+                type: 'hidden',
+                default: 'resource=https%3A%2F%2Fapi.atomicmail.ai%2Fjmap',
+            },
+            {
+                displayName: 'Authentication',
+                name: 'authentication',
+                type: 'hidden',
+                default: 'body',
+            },
+        ];
+        this.test = {
+            request: {
+                baseURL: 'https://auth.atomicmail.ai',
+                url: '/api/v1/agents',
+                method: 'GET',
+            },
+        };
+    }
+}
+exports.AtomicMailOAuth2Api = AtomicMailOAuth2Api;
+//# sourceMappingURL=AtomicMailOAuth2Api.credentials.js.map

--- a/integrations/n8n/atomicmail/dist/nodes/AtomicMail/AtomicMail.node.js
+++ b/integrations/n8n/atomicmail/dist/nodes/AtomicMail/AtomicMail.node.js
@@ -5,6 +5,7 @@ const n8n_workflow_1 = require("n8n-workflow");
 const index_js_1 = require("../../vendor/agentic-core/index.js");
 const attachments_1 = require("../../lib/attachments");
 const jmap_1 = require("../../lib/jmap");
+const oauth_1 = require("../../lib/oauth");
 const session_1 = require("../../lib/session");
 const props_1 = require("../../lib/props");
 function unwrapJmapResult(context, itemIndex, result) {
@@ -34,11 +35,43 @@ class AtomicMail {
             usableAsTool: true,
             credentials: [
                 {
+                    name: 'atomicMailOAuth2Api',
+                    required: false,
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                    },
+                },
+                {
                     name: 'atomicMailApi',
                     required: false,
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
             ],
             properties: [
+                {
+                    displayName: 'Authentication',
+                    name: 'authentication',
+                    type: 'options',
+                    noDataExpression: true,
+                    options: [
+                        {
+                            name: 'API Key (Legacy)',
+                            value: 'apiKey',
+                            description: 'Agent-owned inbox via the proof-of-work path',
+                        },
+                        {
+                            name: 'OAuth2 (Recommended)',
+                            value: 'oAuth2',
+                            description: 'A person signs in once and authorizes n8n — no proof of work',
+                        },
+                    ],
+                    default: 'oAuth2',
+                    displayOptions: {
+                        hide: { resource: ['help'] },
+                    },
+                },
                 {
                     displayName: 'Resource',
                     name: 'resource',
@@ -115,12 +148,27 @@ class AtomicMail {
                     default: 'get',
                 },
                 {
+                    displayName: 'Inbox Name or ID',
+                    name: 'inbox',
+                    type: 'options',
+                    typeOptions: {
+                        loadOptionsMethod: 'getInboxes',
+                    },
+                    default: '',
+                    description: 'Which inbox to act as. Leave empty to auto-select when the connection has exactly one inbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                        hide: { resource: ['account', 'help'] },
+                    },
+                },
+                {
                     displayName: 'Account Namespace',
                     name: 'accountId',
                     type: 'string',
                     default: 'default',
                     description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes in this workflow',
                     displayOptions: {
+                        show: { authentication: ['apiKey'] },
                         hide: { resource: ['help'] },
                     },
                 },
@@ -132,6 +180,7 @@ class AtomicMail {
                     default: '',
                     description: 'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
                     displayOptions: {
+                        show: { authentication: ['apiKey'] },
                         hide: { resource: ['account', 'help'] },
                     },
                 },
@@ -302,9 +351,20 @@ class AtomicMail {
                 },
             ],
         };
+        this.methods = {
+            loadOptions: {
+                async getInboxes() {
+                    const inboxes = await (0, oauth_1.listOAuthInboxes)(this);
+                    return inboxes.map((inbox) => ({
+                        name: inbox.inboxId ? `${inbox.inboxId} (${inbox.accountId})` : inbox.accountId,
+                        value: inbox.accountId,
+                    }));
+                },
+            },
+        };
     }
     async execute() {
-        var _a, _b, _c, _d;
+        var _a, _b, _c, _d, _e;
         const items = this.getInputData();
         const returnData = [];
         for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
@@ -321,8 +381,120 @@ class AtomicMail {
                     });
                     continue;
                 }
-                const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', itemIndex));
                 const itemJson = (_a = items[itemIndex]) === null || _a === void 0 ? void 0 : _a.json;
+                const authentication = this.getNodeParameter('authentication', itemIndex, 'oAuth2');
+                if (authentication === 'oAuth2' && (await (0, oauth_1.hasOAuthCredential)(this))) {
+                    if (resource === 'account') {
+                        throw new n8n_workflow_1.NodeOperationError(this.getNode(), 'Register applies to the legacy API-key (proof-of-work) path. With OAuth the inbox is created when you connect the Atomic Mail OAuth2 credential — switch Authentication to "API Key (Legacy)" to use Register.', { itemIndex });
+                    }
+                    const oauthAccountId = await (0, oauth_1.resolveOAuthAccountId)(this, this.getNodeParameter('inbox', itemIndex, ''));
+                    const inboxContext = await (0, oauth_1.ensureOAuthInboxContext)(this, staticData, oauthAccountId);
+                    if (resource === 'inbox' && operation === 'list') {
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.listInboxBody)(inboxContext.mailboxId)));
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    if (resource === 'email' && operation === 'send') {
+                        const to = (0, props_1.requiredString)(this.getNodeParameter('to', itemIndex), 'to');
+                        const subject = (0, props_1.requiredString)(this.getNodeParameter('subject', itemIndex), 'subject');
+                        const body = (0, props_1.requiredString)(this.getNodeParameter('body', itemIndex), 'body');
+                        const binaryProperty = (0, props_1.optionalTrimmedString)(this.getNodeParameter('binaryProperty', itemIndex, ''));
+                        if (binaryProperty) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), 'Binary attachments are not yet supported on the OAuth path. Switch Authentication to "API Key (Legacy)" to send attachments.', { itemIndex });
+                        }
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.sendMailBody)({ context: inboxContext, to, subject, body })));
+                        const setError = (0, oauth_1.jmapSetErrorMessage)(result.body);
+                        if (setError) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), setError, { itemIndex });
+                        }
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    if (resource === 'email' && operation === 'reply') {
+                        const mailId = (0, props_1.requiredString)(this.getNodeParameter('mailId', itemIndex), 'mailId');
+                        const body = (0, props_1.requiredString)(this.getNodeParameter('body', itemIndex), 'body');
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.replyBody)({ context: inboxContext, mailId, body })));
+                        const setError = (0, oauth_1.jmapSetErrorMessage)(result.body);
+                        if (setError) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), setError, { itemIndex });
+                        }
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    if (resource === 'jmap' && operation === 'request') {
+                        const requestSource = this.getNodeParameter('requestSource', itemIndex, 'preset');
+                        const dryRun = this.getNodeParameter('dryRun', itemIndex, false);
+                        if (dryRun) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), 'Dry run is only supported with the API-key (legacy) credential.', { itemIndex });
+                        }
+                        const parsedVars = (0, jmap_1.parseVarsJson)(this.getNodeParameter('vars', itemIndex, ''));
+                        if (!parsedVars.ok) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), parsedVars.message, { itemIndex });
+                        }
+                        let opsJson;
+                        if (requestSource === 'inline') {
+                            const opsParam = this.getNodeParameter('ops', itemIndex, '');
+                            opsJson =
+                                typeof opsParam === 'string'
+                                    ? (0, props_1.optionalTrimmedString)(opsParam)
+                                    : opsParam && typeof opsParam === 'object'
+                                        ? JSON.stringify(opsParam)
+                                        : undefined;
+                            if (!opsJson) {
+                                throw new n8n_workflow_1.NodeOperationError(this.getNode(), (0, index_js_1.sharedError)('mcp_ops_required'), {
+                                    itemIndex,
+                                });
+                            }
+                        }
+                        else {
+                            const opsFile = (0, props_1.requiredString)(this.getNodeParameter('opsFile', itemIndex, ''), 'opsFile');
+                            opsJson = await (0, index_js_1.readOpsFile)('n8n://oauth', opsFile);
+                        }
+                        const substituted = (0, oauth_1.substituteOpsVars)(opsJson, {
+                            ACCOUNT_ID: oauthAccountId,
+                            INBOX: inboxContext.address,
+                            INBOX_MAILBOX_ID: inboxContext.mailboxId,
+                            ...((_b = parsedVars.vars) !== null && _b !== void 0 ? _b : {}),
+                        });
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.opsJsonToBody)(substituted)));
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    throw new n8n_workflow_1.NodeOperationError(this.getNode(), `Unsupported operation ${resource}/${operation}.`, { itemIndex });
+                }
+                const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', itemIndex, 'default'));
                 const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
                 const inlineApiKey = this.getNodeParameter('apiKey', itemIndex, '');
                 if (resource === 'account' && operation === 'ensureRegistered') {
@@ -335,7 +507,7 @@ class AtomicMail {
                                 ...(0, session_1.authPassthrough)(itemJson),
                                 skipped: true,
                                 idempotent: true,
-                                inbox: (_c = (_b = stored === null || stored === void 0 ? void 0 : stored.inbox) !== null && _b !== void 0 ? _b : session.currentInboxId) !== null && _c !== void 0 ? _c : '',
+                                inbox: (_d = (_c = stored === null || stored === void 0 ? void 0 : stored.inbox) !== null && _c !== void 0 ? _c : session.currentInboxId) !== null && _d !== void 0 ? _d : '',
                                 accountId: accountIdResolved,
                                 ...((stored === null || stored === void 0 ? void 0 : stored.apiKey) ? { apiKey: stored.apiKey } : {}),
                             },
@@ -399,7 +571,7 @@ class AtomicMail {
                         TO: to,
                         SUBJECT: subject,
                         BODY: body,
-                        ...((_d = attachmentResult.vars) !== null && _d !== void 0 ? _d : {}),
+                        ...((_e = attachmentResult.vars) !== null && _e !== void 0 ? _e : {}),
                     };
                     const result = unwrapJmapResult(this, itemIndex, await (0, jmap_1.executePreset)(session, attachmentResult.vars
                         ? 'send_mail_blob_attachment.json'

--- a/integrations/n8n/atomicmail/dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js
+++ b/integrations/n8n/atomicmail/dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.AtomicMailTrigger = void 0;
 const n8n_workflow_1 = require("n8n-workflow");
 const jmap_1 = require("../../lib/jmap");
+const oauth_1 = require("../../lib/oauth");
 const session_1 = require("../../lib/session");
 const props_1 = require("../../lib/props");
 function extractEmails(body) {
@@ -50,11 +51,52 @@ class AtomicMailTrigger {
             polling: true,
             credentials: [
                 {
+                    name: 'atomicMailOAuth2Api',
+                    required: false,
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                    },
+                },
+                {
                     name: 'atomicMailApi',
                     required: false,
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
             ],
             properties: [
+                {
+                    displayName: 'Authentication',
+                    name: 'authentication',
+                    type: 'options',
+                    options: [
+                        {
+                            name: 'API Key (Legacy)',
+                            value: 'apiKey',
+                            description: 'Agent-owned inbox via the proof-of-work path',
+                        },
+                        {
+                            name: 'OAuth2 (Recommended)',
+                            value: 'oAuth2',
+                            description: 'A person signs in once and authorizes n8n — no proof of work',
+                        },
+                    ],
+                    default: 'oAuth2',
+                },
+                {
+                    displayName: 'Inbox Name or ID',
+                    name: 'inbox',
+                    type: 'options',
+                    typeOptions: {
+                        loadOptionsMethod: 'getInboxes',
+                    },
+                    default: '',
+                    description: 'Which inbox to poll. Leave empty to auto-select when the connection has exactly one inbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                    },
+                },
                 {
                     displayName: 'Poll Interval (Minutes)',
                     name: 'pollIntervalMinutes',
@@ -72,6 +114,9 @@ class AtomicMailTrigger {
                     type: 'string',
                     default: 'default',
                     description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes',
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
                 {
                     displayName: 'API Key (Optional Override)',
@@ -80,9 +125,23 @@ class AtomicMailTrigger {
                     typeOptions: { password: true },
                     default: '',
                     description: 'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
             ],
             usableAsTool: true,
+        };
+        this.methods = {
+            loadOptions: {
+                async getInboxes() {
+                    const inboxes = await (0, oauth_1.listOAuthInboxes)(this);
+                    return inboxes.map((inbox) => ({
+                        name: inbox.inboxId ? `${inbox.inboxId} (${inbox.accountId})` : inbox.accountId,
+                        value: inbox.accountId,
+                    }));
+                },
+            },
         };
     }
     async poll() {
@@ -93,43 +152,59 @@ class AtomicMailTrigger {
             lastPollMs = Date.now();
             nodeStaticData.lastPollMs = lastPollMs;
         }
-        const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId'));
-        const inlineApiKey = this.getNodeParameter('apiKey', '');
-        const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
-        try {
-            const session = await (0, session_1.resolveSessionForExecute)(credentialStaticData, accountId, credentials, inlineApiKey, true);
-            const result = await (0, jmap_1.executePreset)(session, 'list_inbox.json');
+        const authentication = this.getNodeParameter('authentication', 'oAuth2');
+        const useOAuth = authentication === 'oAuth2' && (await (0, oauth_1.hasOAuthCredential)(this));
+        let emails;
+        if (useOAuth) {
+            const accountId = await (0, oauth_1.resolveOAuthAccountId)(this, this.getNodeParameter('inbox', '')).catch((error) => {
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), error.message);
+            });
+            const inboxContext = await (0, oauth_1.ensureOAuthInboxContext)(this, credentialStaticData, accountId);
+            const result = await (0, oauth_1.jmapViaOAuth)(this, accountId, (0, oauth_1.listInboxBody)(inboxContext.mailboxId));
             if (!result.ok) {
                 throw new n8n_workflow_1.NodeOperationError(this.getNode(), result.message);
             }
-            const emails = extractEmails(result.body);
-            const newLast = emails.reduce((acc, row) => Math.max(acc, receivedMs(row.receivedAt)), lastPollMs);
-            nodeStaticData.lastPollMs = newLast;
-            const fresh = emails
-                .filter((row) => receivedMs(row.receivedAt) > lastPollMs)
-                .map((row) => ({
-                id: row.id,
-                subject: row.subject,
-                from: row.from,
-                preview: row.preview,
-                receivedAt: row.receivedAt,
-            }));
-            if (fresh.length === 0) {
-                return null;
-            }
-            return [
-                fresh.map((row) => ({
-                    json: row,
-                })),
-            ];
+            emails = extractEmails(result.body);
         }
-        catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            if ((0, props_1.optionalTrimmedString)(inlineApiKey) || (credentials === null || credentials === void 0 ? void 0 : credentials.apiKey)) {
-                throw new n8n_workflow_1.NodeOperationError(this.getNode(), message);
+        else {
+            const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', 'default'));
+            const inlineApiKey = this.getNodeParameter('apiKey', '');
+            const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
+            try {
+                const session = await (0, session_1.resolveSessionForExecute)(credentialStaticData, accountId, credentials, inlineApiKey, true);
+                const result = await (0, jmap_1.executePreset)(session, 'list_inbox.json');
+                if (!result.ok) {
+                    throw new n8n_workflow_1.NodeOperationError(this.getNode(), result.message);
+                }
+                emails = extractEmails(result.body);
             }
-            throw new n8n_workflow_1.NodeOperationError(this.getNode(), `${message} Connect an API key credential, paste an API key, or run **Register** first.`);
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                if ((0, props_1.optionalTrimmedString)(inlineApiKey) || (credentials === null || credentials === void 0 ? void 0 : credentials.apiKey)) {
+                    throw new n8n_workflow_1.NodeOperationError(this.getNode(), message);
+                }
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), `${message} Connect the Atomic Mail OAuth2 credential (recommended), connect an API key credential, paste an API key, or run **Register** first.`);
+            }
         }
+        const newLast = emails.reduce((acc, row) => Math.max(acc, receivedMs(row.receivedAt)), lastPollMs);
+        nodeStaticData.lastPollMs = newLast;
+        const fresh = emails
+            .filter((row) => receivedMs(row.receivedAt) > lastPollMs)
+            .map((row) => ({
+            id: row.id,
+            subject: row.subject,
+            from: row.from,
+            preview: row.preview,
+            receivedAt: row.receivedAt,
+        }));
+        if (fresh.length === 0) {
+            return null;
+        }
+        return [
+            fresh.map((row) => ({
+                json: row,
+            })),
+        ];
     }
 }
 exports.AtomicMailTrigger = AtomicMailTrigger;

--- a/integrations/n8n/atomicmail/lib/oauth.ts
+++ b/integrations/n8n/atomicmail/lib/oauth.ts
@@ -1,0 +1,432 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	ILoadOptionsFunctions,
+	IHttpRequestOptions,
+	IPollFunctions,
+} from 'n8n-workflow';
+
+import type { JmapExecutionResult } from './jmap';
+import { optionalTrimmedString } from './props';
+
+export const OAUTH_CREDENTIAL_NAME = 'atomicMailOAuth2Api';
+
+const AUTH_BASE_URL = 'https://auth.atomicmail.ai';
+const JMAP_URL = 'https://api.atomicmail.ai/jmap';
+const DEFAULT_INBOX_DOMAIN = 'atomicmail.ai';
+
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const USING_MAIL = ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'];
+const USING_SUBMISSION = [...USING_MAIL, 'urn:ietf:params:jmap:submission'];
+
+type OAuthRequestContext = IExecuteFunctions | IPollFunctions | ILoadOptionsFunctions;
+type OAuthExecuteContext = IExecuteFunctions | IPollFunctions;
+
+export interface OAuthInbox {
+	accountId: string;
+	inboxId: string;
+	status?: string;
+}
+
+export interface OAuthInboxContext {
+	/** Inbox mailbox id (JMAP Mailbox with role "inbox"). */
+	mailboxId: string;
+	/** Full sender address for this inbox (from /api/v1/agents). */
+	address: string;
+}
+
+export async function hasOAuthCredential(ctx: OAuthRequestContext): Promise<boolean> {
+	const credentials = await ctx.getCredentials(OAUTH_CREDENTIAL_NAME).catch(() => undefined);
+	return Boolean(credentials);
+}
+
+/** Inboxes the connection's owner can act as (GET /api/v1/agents). */
+export async function listOAuthInboxes(ctx: OAuthRequestContext): Promise<OAuthInbox[]> {
+	const response = (await ctx.helpers.httpRequestWithAuthentication.call(
+		ctx,
+		OAUTH_CREDENTIAL_NAME,
+		{
+			method: 'GET',
+			url: `${AUTH_BASE_URL}/api/v1/agents`,
+			json: true,
+		},
+	)) as { agents?: unknown };
+
+	if (!Array.isArray(response.agents)) return [];
+	const out: OAuthInbox[] = [];
+	for (const entry of response.agents) {
+		if (!entry || typeof entry !== 'object') continue;
+		const row = entry as IDataObject;
+		const accountId = optionalTrimmedString(row.accountId);
+		const inboxId = optionalTrimmedString(row.inboxId);
+		if (!accountId || !UUID_RE.test(accountId)) continue;
+		out.push({
+			accountId,
+			inboxId: inboxId ?? '',
+			status: optionalTrimmedString(row.status),
+		});
+	}
+	return out;
+}
+
+/**
+ * Resolve the X-Atomic-Account-Id value: use the configured inbox when set,
+ * otherwise auto-select when the connection has exactly one inbox.
+ */
+export async function resolveOAuthAccountId(
+	ctx: OAuthRequestContext,
+	configured: unknown,
+): Promise<string> {
+	const value = optionalTrimmedString(configured);
+	if (value) {
+		if (!UUID_RE.test(value)) {
+			throw new Error(
+				`Inbox must be an account UUID (got "${value}"). Pick one from the Inbox dropdown.`,
+			);
+		}
+		return value;
+	}
+
+	const inboxes = await listOAuthInboxes(ctx);
+	if (inboxes.length === 1) return inboxes[0].accountId;
+	if (inboxes.length === 0) {
+		throw new Error(
+			'This Atomic Mail connection has no inboxes. Reconnect the OAuth credential and create or pick an inbox at the consent screen.',
+		);
+	}
+	throw new Error(
+		'This Atomic Mail connection has multiple inboxes. Select one in the Inbox parameter.',
+	);
+}
+
+function friendlyJmapError(status: number, body: unknown): string {
+	let error: string | undefined;
+	let description: string | undefined;
+	if (body && typeof body === 'object') {
+		const row = body as IDataObject;
+		error = optionalTrimmedString(row.error);
+		description =
+			optionalTrimmedString(row.error_description) ??
+			optionalTrimmedString((row.error as IDataObject | undefined)?.message);
+	}
+
+	if (status === 403 && error === 'insufficient_scope') {
+		return (
+			'This OAuth connection is read-only (scope mail.read). ' +
+			'Reconnect the Atomic Mail OAuth2 credential with the "Read and Send" scope to send mail.'
+		);
+	}
+	if (status === 403) {
+		return (
+			'The selected inbox is not owned by this OAuth connection (403). ' +
+			'Re-select the Inbox parameter or reconnect the credential.'
+		);
+	}
+	if (status === 400) {
+		return (
+			`Atomic Mail rejected the request (400${error ? `, ${error}` : ''}): ` +
+			`${description ?? 'X-Atomic-Account-Id must be the UUID of an inbox you own.'}`
+		);
+	}
+	if (status === 401) {
+		return (
+			'The OAuth access token was rejected (401 invalid_token). ' +
+			'The grant may have been revoked — reconnect the Atomic Mail OAuth2 credential.'
+		);
+	}
+	const detail = description ?? (typeof body === 'string' ? body : JSON.stringify(body));
+	return `JMAP request failed (HTTP ${status}): ${detail}`;
+}
+
+/**
+ * POST a JMAP request body with the OAuth access token as bearer and the
+ * mandatory X-Atomic-Account-Id header. No PoW, no capability minting —
+ * n8n refreshes the token and persists the rotated refresh token itself.
+ */
+export async function jmapViaOAuth(
+	ctx: OAuthExecuteContext,
+	accountId: string,
+	body: IDataObject,
+): Promise<JmapExecutionResult> {
+	const options: IHttpRequestOptions = {
+		method: 'POST',
+		url: JMAP_URL,
+		headers: {
+			'X-Atomic-Account-Id': accountId,
+			'Content-Type': 'application/json',
+		},
+		body,
+		json: true,
+		returnFullResponse: true,
+		ignoreHttpStatusErrors: true,
+	};
+	const response = (await ctx.helpers.httpRequestWithAuthentication.call(
+		ctx,
+		OAUTH_CREDENTIAL_NAME,
+		options,
+	)) as { statusCode?: number; body?: unknown };
+
+	const status = response.statusCode ?? 0;
+	const responseBody = response.body;
+	if (status >= 200 && status < 300) {
+		return { ok: true, status, body: responseBody };
+	}
+	return {
+		ok: false,
+		status,
+		body: responseBody,
+		message: friendlyJmapError(status, responseBody),
+	};
+}
+
+function inboxContextCacheKey(accountId: string): string {
+	return `atomicMailOAuthInboxContext:${accountId}`;
+}
+
+/**
+ * Mailbox id + sender address for an inbox, cached in workflow static data
+ * (both are stable for the lifetime of the inbox).
+ */
+export async function ensureOAuthInboxContext(
+	ctx: OAuthExecuteContext,
+	cache: IDataObject,
+	accountId: string,
+): Promise<OAuthInboxContext> {
+	const cached = cache[inboxContextCacheKey(accountId)];
+	if (cached && typeof cached === 'object') {
+		const row = cached as IDataObject;
+		const mailboxId = optionalTrimmedString(row.mailboxId);
+		const address = optionalTrimmedString(row.address);
+		if (mailboxId && address) return { mailboxId, address };
+	}
+
+	const inboxes = await listOAuthInboxes(ctx);
+	const inbox = inboxes.find((row) => row.accountId === accountId);
+	if (!inbox) {
+		throw new Error(
+			'The selected inbox is not available on this OAuth connection. Re-select the Inbox parameter.',
+		);
+	}
+	const address = inbox.inboxId.includes('@')
+		? inbox.inboxId
+		: `${inbox.inboxId}@${DEFAULT_INBOX_DOMAIN}`;
+
+	const mailboxResult = await jmapViaOAuth(ctx, accountId, {
+		using: USING_MAIL,
+		methodCalls: [['Mailbox/query', { filter: { role: 'inbox' } }, 'm0']],
+	});
+	if (!mailboxResult.ok) {
+		throw new Error(mailboxResult.message);
+	}
+	const responses = (mailboxResult.body as { methodResponses?: unknown[] })?.methodResponses;
+	const payload = Array.isArray(responses) && Array.isArray(responses[0]) ? responses[0][1] : undefined;
+	const ids = (payload as { ids?: unknown } | undefined)?.ids;
+	const mailboxId = Array.isArray(ids) ? optionalTrimmedString(ids[0]) : undefined;
+	if (!mailboxId) {
+		throw new Error('Could not resolve the inbox mailbox id over JMAP (Mailbox/query returned no ids).');
+	}
+
+	const context: OAuthInboxContext = { mailboxId, address };
+	cache[inboxContextCacheKey(accountId)] = context as unknown as IDataObject;
+	return context;
+}
+
+/**
+ * JMAP bodies for the OAuth path. They mirror the bundled PoW presets, minus
+ * `accountId` in method arguments — the account is pinned server-side from
+ * the X-Atomic-Account-Id header and a body accountId cannot override it.
+ */
+export function listInboxBody(mailboxId: string): IDataObject {
+	return {
+		using: USING_MAIL,
+		methodCalls: [
+			[
+				'Email/query',
+				{
+					filter: { inMailbox: mailboxId },
+					sort: [{ property: 'receivedAt', isAscending: false }],
+					limit: 50,
+				},
+				'q0',
+			],
+			[
+				'Email/get',
+				{
+					'#ids': { resultOf: 'q0', name: 'Email/query', path: '/ids' },
+					properties: ['id', 'threadId', 'receivedAt', 'from', 'to', 'subject', 'preview'],
+				},
+				'g0',
+			],
+		],
+	};
+}
+
+export function sendMailBody(input: {
+	context: OAuthInboxContext;
+	to: string;
+	subject: string;
+	body: string;
+}): IDataObject {
+	const { context, to, subject, body } = input;
+	return {
+		using: USING_SUBMISSION,
+		methodCalls: [
+			[
+				'Email/set',
+				{
+					create: {
+						d1: {
+							mailboxIds: { [context.mailboxId]: true },
+							from: [{ email: context.address }],
+							to: [{ email: to }],
+							subject,
+							textBody: [{ partId: 'b', type: 'text/plain' }],
+							bodyValues: { b: { value: body } },
+							keywords: { $draft: true },
+						},
+					},
+				},
+				'c0',
+			],
+			[
+				'EmailSubmission/set',
+				{
+					create: {
+						s1: {
+							emailId: '#d1',
+							envelope: {
+								mailFrom: { email: context.address },
+								rcptTo: [{ email: to }],
+							},
+						},
+					},
+				},
+				'c1',
+			],
+		],
+	};
+}
+
+export function replyBody(input: {
+	context: OAuthInboxContext;
+	mailId: string;
+	body: string;
+}): IDataObject {
+	const { context, mailId, body } = input;
+	return {
+		using: USING_SUBMISSION,
+		methodCalls: [
+			[
+				'Email/get',
+				{
+					ids: [mailId],
+					properties: ['id', 'threadId', 'from', 'replyTo', 'subject', 'messageId'],
+				},
+				'g0',
+			],
+			[
+				'Email/set',
+				{
+					create: {
+						d1: {
+							mailboxIds: { [context.mailboxId]: true },
+							from: [{ email: context.address }],
+							'#to': { resultOf: 'g0', name: 'Email/get', path: '/list/0/replyTo' },
+							'#subject': { resultOf: 'g0', name: 'Email/get', path: '/list/0/subject' },
+							'#inReplyTo': { resultOf: 'g0', name: 'Email/get', path: '/list/0/messageId' },
+							textBody: [{ partId: 'b', type: 'text/plain' }],
+							bodyValues: { b: { value: body } },
+							keywords: { $draft: true },
+						},
+					},
+				},
+				'c0',
+			],
+			[
+				'EmailSubmission/set',
+				{
+					create: {
+						s1: {
+							emailId: '#d1',
+							envelope: {
+								mailFrom: { email: context.address },
+								'#rcptTo': { resultOf: 'g0', name: 'Email/get', path: '/list/0/replyTo' },
+							},
+						},
+					},
+				},
+				'c1',
+			],
+		],
+	};
+}
+
+/**
+ * JMAP reports set failures inside an HTTP 200 — a rejected send arrives as a
+ * populated notCreated/notSubmitted rather than an HTTP error. Returns a
+ * message when the response contains one.
+ */
+export function jmapSetErrorMessage(body: unknown): string | undefined {
+	const methodResponses = (body as { methodResponses?: unknown[] } | undefined)?.methodResponses;
+	if (!Array.isArray(methodResponses)) return undefined;
+	for (const entry of methodResponses) {
+		if (!Array.isArray(entry) || entry.length < 2) continue;
+		const payload = entry[1] as IDataObject | undefined;
+		if (!payload || typeof payload !== 'object') continue;
+		for (const key of ['notCreated', 'notSubmitted', 'notUpdated']) {
+			const failures = payload[key];
+			if (failures && typeof failures === 'object' && Object.keys(failures).length > 0) {
+				return `JMAP ${String(entry[0])} reported ${key}: ${JSON.stringify(failures)}`;
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Substitute $VAR tokens in raw ops JSON text for the OAuth path (session
+ * placeholders plus user vars), escaping values for JSON string context.
+ * Longer names are replaced first so $INBOX_MAILBOX_ID wins over $INBOX.
+ */
+export function substituteOpsVars(
+	opsJson: string,
+	vars: Record<string, string>,
+): string {
+	const names = Object.keys(vars).sort((a, b) => b.length - a.length);
+	let out = opsJson;
+	for (const name of names) {
+		const escaped = JSON.stringify(vars[name]).slice(1, -1);
+		out = out.split(`$${name}`).join(escaped);
+	}
+	return out;
+}
+
+/** Parse raw ops JSON (methodCalls array or full envelope) into a request body. */
+export function opsJsonToBody(opsJson: string): IDataObject {
+	let parsed: unknown;
+	let parseError: string | undefined;
+	try {
+		parsed = JSON.parse(opsJson);
+	} catch (err) {
+		parseError = err instanceof Error ? err.message : String(err);
+	}
+	if (parseError !== undefined) {
+		throw new Error(`ops must be valid JSON: ${parseError}`);
+	}
+	if (Array.isArray(parsed)) {
+		return { using: USING_SUBMISSION, methodCalls: parsed };
+	}
+	if (parsed && typeof parsed === 'object') {
+		const envelope = parsed as IDataObject;
+		if (!Array.isArray(envelope.methodCalls)) {
+			throw new Error('ops envelope must contain a methodCalls array.');
+		}
+		if (!Array.isArray(envelope.using)) {
+			envelope.using = USING_SUBMISSION;
+		}
+		return envelope;
+	}
+	throw new Error('ops must be a JMAP methodCalls array or envelope object.');
+}

--- a/integrations/n8n/atomicmail/nodes/AtomicMail/AtomicMail.node.ts
+++ b/integrations/n8n/atomicmail/nodes/AtomicMail/AtomicMail.node.ts
@@ -1,7 +1,9 @@
 import type {
 	IExecuteFunctions,
 	IDataObject,
+	ILoadOptionsFunctions,
 	INodeExecutionData,
+	INodePropertyOptions,
 	INodeType,
 	INodeTypeDescription,
 } from 'n8n-workflow';
@@ -11,6 +13,7 @@ import {
 	getHelp,
 	HELP_TOPIC_LIST,
 	postRegisterCronReminder,
+	readOpsFile,
 	sharedError,
 } from '../../vendor/agentic-core/index.js';
 import { attachmentVarsFromBinaryProperty } from '../../lib/attachments';
@@ -20,6 +23,20 @@ import {
 	parseVarsJson,
 	type JmapExecutionResult,
 } from '../../lib/jmap';
+import {
+	ensureOAuthInboxContext,
+	hasOAuthCredential,
+	jmapSetErrorMessage,
+	jmapViaOAuth,
+	listInboxBody,
+	listOAuthInboxes,
+	opsJsonToBody,
+	replyBody,
+	resolveOAuthAccountId,
+	sendMailBody,
+	substituteOpsVars,
+	type OAuthInboxContext,
+} from '../../lib/oauth';
 import {
 	authPassthrough,
 	credentialsFromData,
@@ -61,11 +78,43 @@ export class AtomicMail implements INodeType {
 		usableAsTool: true,
 		credentials: [
 			{
+				name: 'atomicMailOAuth2Api',
+				required: false,
+				displayOptions: {
+					show: { authentication: ['oAuth2'] },
+				},
+			},
+			{
 				name: 'atomicMailApi',
 				required: false,
+				displayOptions: {
+					show: { authentication: ['apiKey'] },
+				},
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'API Key (Legacy)',
+						value: 'apiKey',
+						description: 'Agent-owned inbox via the proof-of-work path',
+					},
+					{
+						name: 'OAuth2 (Recommended)',
+						value: 'oAuth2',
+						description: 'A person signs in once and authorizes n8n — no proof of work',
+					},
+				],
+				default: 'oAuth2',
+				displayOptions: {
+					hide: { resource: ['help'] },
+				},
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',
@@ -142,12 +191,28 @@ export class AtomicMail implements INodeType {
 				default: 'get',
 			},
 			{
+				displayName: 'Inbox Name or ID',
+				name: 'inbox',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getInboxes',
+				},
+				default: '',
+				description:
+					'Which inbox to act as. Leave empty to auto-select when the connection has exactly one inbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				displayOptions: {
+					show: { authentication: ['oAuth2'] },
+					hide: { resource: ['account', 'help'] },
+				},
+			},
+			{
 				displayName: 'Account Namespace',
 				name: 'accountId',
 				type: 'string',
 				default: 'default',
 				description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes in this workflow',
 				displayOptions: {
+					show: { authentication: ['apiKey'] },
 					hide: { resource: ['help'] },
 				},
 			},
@@ -160,6 +225,7 @@ export class AtomicMail implements INodeType {
 				description:
 					'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
 				displayOptions: {
+					show: { authentication: ['apiKey'] },
 					hide: { resource: ['account', 'help'] },
 				},
 			},
@@ -331,6 +397,18 @@ export class AtomicMail implements INodeType {
 		],
 	};
 
+	methods = {
+		loadOptions: {
+			async getInboxes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const inboxes = await listOAuthInboxes(this);
+				return inboxes.map((inbox) => ({
+					name: inbox.inboxId ? `${inbox.inboxId} (${inbox.accountId})` : inbox.accountId,
+					value: inbox.accountId,
+				}));
+			},
+		},
+	};
+
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
@@ -352,8 +430,196 @@ export class AtomicMail implements INodeType {
 					continue;
 				}
 
-				const accountId = normalizeAccountId(this.getNodeParameter('accountId', itemIndex));
 				const itemJson = items[itemIndex]?.json;
+				const authentication = this.getNodeParameter(
+					'authentication',
+					itemIndex,
+					'oAuth2',
+				) as string;
+				// Workflows saved before the OAuth migration have no `authentication`
+				// parameter and resolve to the new default; fall back to the legacy
+				// PoW path when no OAuth credential is actually connected.
+				if (authentication === 'oAuth2' && (await hasOAuthCredential(this))) {
+					if (resource === 'account') {
+						throw new NodeOperationError(
+							this.getNode(),
+							'Register applies to the legacy API-key (proof-of-work) path. With OAuth the inbox is created when you connect the Atomic Mail OAuth2 credential — switch Authentication to "API Key (Legacy)" to use Register.',
+							{ itemIndex },
+						);
+					}
+
+					const oauthAccountId = await resolveOAuthAccountId(
+						this,
+						this.getNodeParameter('inbox', itemIndex, ''),
+					);
+					const inboxContext: OAuthInboxContext = await ensureOAuthInboxContext(
+						this,
+						staticData,
+						oauthAccountId,
+					);
+
+					if (resource === 'inbox' && operation === 'list') {
+						const result = unwrapJmapResult(
+							this,
+							itemIndex,
+							await jmapViaOAuth(this, oauthAccountId, listInboxBody(inboxContext.mailboxId)),
+						);
+						returnData.push({
+							json: {
+								...authPassthrough(itemJson),
+								ok: true,
+								status: result.status,
+								body: result.body as IDataObject,
+							},
+							pairedItem: { item: itemIndex },
+						});
+						continue;
+					}
+
+					if (resource === 'email' && operation === 'send') {
+						const to = requiredString(this.getNodeParameter('to', itemIndex), 'to');
+						const subject = requiredString(
+							this.getNodeParameter('subject', itemIndex),
+							'subject',
+						);
+						const body = requiredString(this.getNodeParameter('body', itemIndex), 'body');
+						const binaryProperty = optionalTrimmedString(
+							this.getNodeParameter('binaryProperty', itemIndex, ''),
+						);
+						if (binaryProperty) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'Binary attachments are not yet supported on the OAuth path. Switch Authentication to "API Key (Legacy)" to send attachments.',
+								{ itemIndex },
+							);
+						}
+						const result = unwrapJmapResult(
+							this,
+							itemIndex,
+							await jmapViaOAuth(
+								this,
+								oauthAccountId,
+								sendMailBody({ context: inboxContext, to, subject, body }),
+							),
+						);
+						const setError = jmapSetErrorMessage(result.body);
+						if (setError) {
+							throw new NodeOperationError(this.getNode(), setError, { itemIndex });
+						}
+						returnData.push({
+							json: {
+								...authPassthrough(itemJson),
+								ok: true,
+								status: result.status,
+								body: result.body as IDataObject,
+							},
+							pairedItem: { item: itemIndex },
+						});
+						continue;
+					}
+
+					if (resource === 'email' && operation === 'reply') {
+						const mailId = requiredString(this.getNodeParameter('mailId', itemIndex), 'mailId');
+						const body = requiredString(this.getNodeParameter('body', itemIndex), 'body');
+						const result = unwrapJmapResult(
+							this,
+							itemIndex,
+							await jmapViaOAuth(
+								this,
+								oauthAccountId,
+								replyBody({ context: inboxContext, mailId, body }),
+							),
+						);
+						const setError = jmapSetErrorMessage(result.body);
+						if (setError) {
+							throw new NodeOperationError(this.getNode(), setError, { itemIndex });
+						}
+						returnData.push({
+							json: {
+								...authPassthrough(itemJson),
+								ok: true,
+								status: result.status,
+								body: result.body as IDataObject,
+							},
+							pairedItem: { item: itemIndex },
+						});
+						continue;
+					}
+
+					if (resource === 'jmap' && operation === 'request') {
+						const requestSource = this.getNodeParameter(
+							'requestSource',
+							itemIndex,
+							'preset',
+						) as string;
+						const dryRun = this.getNodeParameter('dryRun', itemIndex, false) as boolean;
+						if (dryRun) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'Dry run is only supported with the API-key (legacy) credential.',
+								{ itemIndex },
+							);
+						}
+						const parsedVars = parseVarsJson(this.getNodeParameter('vars', itemIndex, ''));
+						if (!parsedVars.ok) {
+							throw new NodeOperationError(this.getNode(), parsedVars.message, { itemIndex });
+						}
+
+						let opsJson: string | undefined;
+						if (requestSource === 'inline') {
+							const opsParam = this.getNodeParameter('ops', itemIndex, '') as string | object;
+							opsJson =
+								typeof opsParam === 'string'
+									? optionalTrimmedString(opsParam)
+									: opsParam && typeof opsParam === 'object'
+										? JSON.stringify(opsParam)
+										: undefined;
+							if (!opsJson) {
+								throw new NodeOperationError(this.getNode(), sharedError('mcp_ops_required'), {
+									itemIndex,
+								});
+							}
+						} else {
+							const opsFile = requiredString(
+								this.getNodeParameter('opsFile', itemIndex, ''),
+								'opsFile',
+							);
+							opsJson = await readOpsFile('n8n://oauth', opsFile);
+						}
+
+						const substituted = substituteOpsVars(opsJson, {
+							ACCOUNT_ID: oauthAccountId,
+							INBOX: inboxContext.address,
+							INBOX_MAILBOX_ID: inboxContext.mailboxId,
+							...(parsedVars.vars ?? {}),
+						});
+						const result = unwrapJmapResult(
+							this,
+							itemIndex,
+							await jmapViaOAuth(this, oauthAccountId, opsJsonToBody(substituted)),
+						);
+						returnData.push({
+							json: {
+								...authPassthrough(itemJson),
+								ok: true,
+								status: result.status,
+								body: result.body as IDataObject,
+							},
+							pairedItem: { item: itemIndex },
+						});
+						continue;
+					}
+
+					throw new NodeOperationError(
+						this.getNode(),
+						`Unsupported operation ${resource}/${operation}.`,
+						{ itemIndex },
+					);
+				}
+
+				const accountId = normalizeAccountId(
+					this.getNodeParameter('accountId', itemIndex, 'default'),
+				);
 				const credentials = credentialsFromData(
 					await this.getCredentials('atomicMailApi').catch(() => undefined),
 				);

--- a/integrations/n8n/atomicmail/nodes/AtomicMailTrigger/AtomicMailTrigger.node.ts
+++ b/integrations/n8n/atomicmail/nodes/AtomicMailTrigger/AtomicMailTrigger.node.ts
@@ -1,6 +1,8 @@
 import type {
 	IDataObject,
+	ILoadOptionsFunctions,
 	INodeExecutionData,
+	INodePropertyOptions,
 	INodeType,
 	INodeTypeDescription,
 	IPollFunctions,
@@ -8,6 +10,14 @@ import type {
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import { executePreset } from '../../lib/jmap';
+import {
+	ensureOAuthInboxContext,
+	hasOAuthCredential,
+	jmapViaOAuth,
+	listInboxBody,
+	listOAuthInboxes,
+	resolveOAuthAccountId,
+} from '../../lib/oauth';
 import {
 	credentialsFromData,
 	resolveSessionForExecute,
@@ -68,11 +78,53 @@ export class AtomicMailTrigger implements INodeType {
 		polling: true,
 		credentials: [
 			{
+				name: 'atomicMailOAuth2Api',
+				required: false,
+				displayOptions: {
+					show: { authentication: ['oAuth2'] },
+				},
+			},
+			{
 				name: 'atomicMailApi',
 				required: false,
+				displayOptions: {
+					show: { authentication: ['apiKey'] },
+				},
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						name: 'API Key (Legacy)',
+						value: 'apiKey',
+						description: 'Agent-owned inbox via the proof-of-work path',
+					},
+					{
+						name: 'OAuth2 (Recommended)',
+						value: 'oAuth2',
+						description: 'A person signs in once and authorizes n8n — no proof of work',
+					},
+				],
+				default: 'oAuth2',
+			},
+			{
+				displayName: 'Inbox Name or ID',
+				name: 'inbox',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getInboxes',
+				},
+				default: '',
+				description:
+					'Which inbox to poll. Leave empty to auto-select when the connection has exactly one inbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				displayOptions: {
+					show: { authentication: ['oAuth2'] },
+				},
+			},
 			{
 				displayName: 'Poll Interval (Minutes)',
 				name: 'pollIntervalMinutes',
@@ -90,6 +142,9 @@ export class AtomicMailTrigger implements INodeType {
 				type: 'string',
 				default: 'default',
 				description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes',
+				displayOptions: {
+					show: { authentication: ['apiKey'] },
+				},
 			},
 			{
 				displayName: 'API Key (Optional Override)',
@@ -99,9 +154,24 @@ export class AtomicMailTrigger implements INodeType {
 				default: '',
 				description:
 					'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
+				displayOptions: {
+					show: { authentication: ['apiKey'] },
+				},
 			},
 		],
 		usableAsTool: true,
+	};
+
+	methods = {
+		loadOptions: {
+			async getInboxes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const inboxes = await listOAuthInboxes(this);
+				return inboxes.map((inbox) => ({
+					name: inbox.inboxId ? `${inbox.inboxId} (${inbox.accountId})` : inbox.accountId,
+					value: inbox.accountId,
+				}));
+			},
+		},
 	};
 
 	async poll(this: IPollFunctions): Promise<INodeExecutionData[][] | null> {
@@ -113,60 +183,86 @@ export class AtomicMailTrigger implements INodeType {
 			nodeStaticData.lastPollMs = lastPollMs;
 		}
 
-		const accountId = normalizeAccountId(this.getNodeParameter('accountId'));
-		const inlineApiKey = this.getNodeParameter('apiKey', '') as string;
-		const credentials = credentialsFromData(
-			await this.getCredentials('atomicMailApi').catch(() => undefined),
-		);
+		const authentication = this.getNodeParameter('authentication', 'oAuth2') as string;
+		// Workflows saved before the OAuth migration have no `authentication`
+		// parameter and resolve to the new default; fall back to the legacy PoW
+		// path when no OAuth credential is actually connected.
+		const useOAuth = authentication === 'oAuth2' && (await hasOAuthCredential(this));
 
-		try {
-			const session = await resolveSessionForExecute(
+		let emails: InboxEmailRow[];
+		if (useOAuth) {
+			const accountId = await resolveOAuthAccountId(
+				this,
+				this.getNodeParameter('inbox', ''),
+			).catch((error: Error) => {
+				throw new NodeOperationError(this.getNode(), error.message);
+			});
+			const inboxContext = await ensureOAuthInboxContext(
+				this,
 				credentialStaticData,
 				accountId,
-				credentials,
-				inlineApiKey,
-				true,
 			);
-			const result = await executePreset(session, 'list_inbox.json');
+			const result = await jmapViaOAuth(this, accountId, listInboxBody(inboxContext.mailboxId));
 			if (!result.ok) {
 				throw new NodeOperationError(this.getNode(), result.message);
 			}
-			const emails = extractEmails(result.body);
-
-			const newLast = emails.reduce(
-				(acc, row) => Math.max(acc, receivedMs(row.receivedAt)),
-				lastPollMs,
+			emails = extractEmails(result.body);
+		} else {
+			const accountId = normalizeAccountId(this.getNodeParameter('accountId', 'default'));
+			const inlineApiKey = this.getNodeParameter('apiKey', '') as string;
+			const credentials = credentialsFromData(
+				await this.getCredentials('atomicMailApi').catch(() => undefined),
 			);
-			nodeStaticData.lastPollMs = newLast;
 
-			const fresh = emails
-				.filter((row) => receivedMs(row.receivedAt) > lastPollMs)
-				.map((row) => ({
-					id: row.id,
-					subject: row.subject,
-					from: row.from,
-					preview: row.preview,
-					receivedAt: row.receivedAt,
-				}));
-
-			if (fresh.length === 0) {
-				return null;
+			try {
+				const session = await resolveSessionForExecute(
+					credentialStaticData,
+					accountId,
+					credentials,
+					inlineApiKey,
+					true,
+				);
+				const result = await executePreset(session, 'list_inbox.json');
+				if (!result.ok) {
+					throw new NodeOperationError(this.getNode(), result.message);
+				}
+				emails = extractEmails(result.body);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				if (optionalTrimmedString(inlineApiKey) || credentials?.apiKey) {
+					throw new NodeOperationError(this.getNode(), message);
+				}
+				throw new NodeOperationError(
+					this.getNode(),
+					`${message} Connect the Atomic Mail OAuth2 credential (recommended), connect an API key credential, paste an API key, or run **Register** first.`,
+				);
 			}
-
-			return [
-				fresh.map((row) => ({
-					json: row as IDataObject,
-				})),
-			];
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			if (optionalTrimmedString(inlineApiKey) || credentials?.apiKey) {
-				throw new NodeOperationError(this.getNode(), message);
-			}
-			throw new NodeOperationError(
-				this.getNode(),
-				`${message} Connect an API key credential, paste an API key, or run **Register** first.`,
-			);
 		}
+
+		const newLast = emails.reduce(
+			(acc, row) => Math.max(acc, receivedMs(row.receivedAt)),
+			lastPollMs,
+		);
+		nodeStaticData.lastPollMs = newLast;
+
+		const fresh = emails
+			.filter((row) => receivedMs(row.receivedAt) > lastPollMs)
+			.map((row) => ({
+				id: row.id,
+				subject: row.subject,
+				from: row.from,
+				preview: row.preview,
+				receivedAt: row.receivedAt,
+			}));
+
+		if (fresh.length === 0) {
+			return null;
+		}
+
+		return [
+			fresh.map((row) => ({
+				json: row as IDataObject,
+			})),
+		];
 	}
 }

--- a/integrations/n8n/atomicmail/package-lock.json
+++ b/integrations/n8n/atomicmail/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@atomicmail/n8n-nodes-atomicmail",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@atomicmail/n8n-nodes-atomicmail",
-      "version": "0.3.11",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@n8n/node-cli": "*",

--- a/integrations/n8n/atomicmail/package.json
+++ b/integrations/n8n/atomicmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomicmail/n8n-nodes-atomicmail",
-  "version": "0.3.23",
+  "version": "0.4.0",
   "description": "Atomic Mail inbox for n8n — register, JMAP mail, and inbox polling triggers.",
   "license": "MIT",
   "homepage": "https://github.com/Atomic-Mail/atomic-mail-agentic/tree/develop/integrations/n8n/atomicmail",
@@ -39,7 +39,8 @@
     "n8nNodesApiVersion": 1,
     "strict": true,
     "credentials": [
-      "dist/credentials/AtomicMailApi.credentials.js"
+      "dist/credentials/AtomicMailApi.credentials.js",
+      "dist/credentials/AtomicMailOAuth2Api.credentials.js"
     ],
     "nodes": [
       "dist/nodes/AtomicMail/AtomicMail.node.js",

--- a/integrations/n8n/atomicmail/scripts/sync-vetting-paths.mjs
+++ b/integrations/n8n/atomicmail/scripts/sync-vetting-paths.mjs
@@ -20,6 +20,8 @@ const repoRoot = path.resolve(n8nDir, '../..');
 const vettingPaths = [
 	'credentials/AtomicMailApi.credentials.ts',
 	'dist/credentials/AtomicMailApi.credentials.js',
+	'credentials/AtomicMailOAuth2Api.credentials.ts',
+	'dist/credentials/AtomicMailOAuth2Api.credentials.js',
 	'dist/nodes/AtomicMail/AtomicMail.node.js',
 	'dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js',
 ];

--- a/integrations/n8n/vetting/credentials/AtomicMailOAuth2Api.credentials.ts
+++ b/integrations/n8n/vetting/credentials/AtomicMailOAuth2Api.credentials.ts
@@ -1,0 +1,113 @@
+import type {
+	Icon,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+/**
+ * OAuth 2.0 authorization-code + PKCE (S256) against auth.atomicmail.ai.
+ * Public client — no client secret. n8n's `pkce` grant type generates the
+ * verifier/S256 challenge and rotates the refresh token automatically.
+ * The access token is used directly as the JMAP bearer (see docs/oauth.md).
+ */
+export class AtomicMailOAuth2Api implements ICredentialType {
+	name = 'atomicMailOAuth2Api';
+
+	extends = ['oAuth2Api'];
+
+	displayName = 'Atomic Mail OAuth2 API';
+
+	icon: Icon = {
+		light: 'file:../icons/atomicmail.svg',
+		dark: 'file:../icons/atomicmail.dark.svg',
+	};
+
+	documentationUrl =
+		'https://github.com/Atomic-Mail/atomic-mail-agentic/blob/develop/docs/n8n.md';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'hidden',
+			default: 'pkce',
+		},
+		{
+			displayName: 'Authorization URL',
+			name: 'authUrl',
+			type: 'hidden',
+			default: 'https://auth.atomicmail.ai/oauth/authorize',
+		},
+		{
+			displayName: 'Access Token URL',
+			name: 'accessTokenUrl',
+			type: 'hidden',
+			default: 'https://auth.atomicmail.ai/oauth/token',
+		},
+		{
+			// Public client for n8n Cloud (redirect https://oauth.n8n.cloud/oauth2/callback),
+			// registered via RFC 7591 dynamic client registration and validated live
+			// end-to-end on n8n Cloud. Self-hosted users override this with their own
+			// client registered for their instance's callback URL (see docs/n8n.md) —
+			// each host has a distinct redirect_uri that must be registered on the client.
+			displayName: 'Client ID',
+			name: 'clientId',
+			type: 'string',
+			default: 'urn:atomicmail:client:dyn:81e0d57f-59f6-42f6-9074-9efc7c9f82fa',
+			required: true,
+			description:
+				'Public OAuth client ID. n8n Cloud works with the shipped default. Self-hosted: register your own with POST https://auth.atomicmail.ai/oauth/register (RFC 7591), listing this credential\'s OAuth callback URL in redirect_uris.',
+		},
+		{
+			// Public client — the auth server accepts token_endpoint_auth_method
+			// "none"; no secret exists.
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'hidden',
+			typeOptions: { password: true },
+			default: '',
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'options',
+			options: [
+				{
+					name: 'Read Only (mail.read)',
+					value: 'mail.read',
+				},
+				{
+					name: 'Read and Send (mail.read mail.send)',
+					value: 'mail.read mail.send',
+				},
+			],
+			default: 'mail.read',
+			description:
+				'Sending requires mail.send. The consent screen may still narrow the grant to read-only; a read-only connection gets a clear insufficient_scope error on send.',
+		},
+		{
+			// `resource` (RFC 8707) must match https://api.atomicmail.ai/jmap byte
+			// for byte after URL-decoding; n8n appends this string to the authorize
+			// URL as-is, so it is pre-encoded here.
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
+			type: 'hidden',
+			default: 'resource=https%3A%2F%2Fapi.atomicmail.ai%2Fjmap',
+		},
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden',
+			default: 'body',
+		},
+	];
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: 'https://auth.atomicmail.ai',
+			url: '/api/v1/agents',
+			method: 'GET',
+		},
+	};
+}

--- a/integrations/n8n/vetting/dist/credentials/AtomicMailOAuth2Api.credentials.js
+++ b/integrations/n8n/vetting/dist/credentials/AtomicMailOAuth2Api.credentials.js
@@ -1,0 +1,88 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AtomicMailOAuth2Api = void 0;
+class AtomicMailOAuth2Api {
+    constructor() {
+        this.name = 'atomicMailOAuth2Api';
+        this.extends = ['oAuth2Api'];
+        this.displayName = 'Atomic Mail OAuth2 API';
+        this.icon = {
+            light: 'file:../icons/atomicmail.svg',
+            dark: 'file:../icons/atomicmail.dark.svg',
+        };
+        this.documentationUrl = 'https://github.com/Atomic-Mail/atomic-mail-agentic/blob/develop/docs/n8n.md';
+        this.properties = [
+            {
+                displayName: 'Grant Type',
+                name: 'grantType',
+                type: 'hidden',
+                default: 'pkce',
+            },
+            {
+                displayName: 'Authorization URL',
+                name: 'authUrl',
+                type: 'hidden',
+                default: 'https://auth.atomicmail.ai/oauth/authorize',
+            },
+            {
+                displayName: 'Access Token URL',
+                name: 'accessTokenUrl',
+                type: 'hidden',
+                default: 'https://auth.atomicmail.ai/oauth/token',
+            },
+            {
+                displayName: 'Client ID',
+                name: 'clientId',
+                type: 'string',
+                default: 'urn:atomicmail:client:dyn:81e0d57f-59f6-42f6-9074-9efc7c9f82fa',
+                required: true,
+                description: 'Public OAuth client ID. n8n Cloud works with the shipped default. Self-hosted: register your own with POST https://auth.atomicmail.ai/oauth/register (RFC 7591), listing this credential\'s OAuth callback URL in redirect_uris.',
+            },
+            {
+                displayName: 'Client Secret',
+                name: 'clientSecret',
+                type: 'hidden',
+                typeOptions: { password: true },
+                default: '',
+            },
+            {
+                displayName: 'Scope',
+                name: 'scope',
+                type: 'options',
+                options: [
+                    {
+                        name: 'Read Only (mail.read)',
+                        value: 'mail.read',
+                    },
+                    {
+                        name: 'Read and Send (mail.read mail.send)',
+                        value: 'mail.read mail.send',
+                    },
+                ],
+                default: 'mail.read',
+                description: 'Sending requires mail.send. The consent screen may still narrow the grant to read-only; a read-only connection gets a clear insufficient_scope error on send.',
+            },
+            {
+                displayName: 'Auth URI Query Parameters',
+                name: 'authQueryParameters',
+                type: 'hidden',
+                default: 'resource=https%3A%2F%2Fapi.atomicmail.ai%2Fjmap',
+            },
+            {
+                displayName: 'Authentication',
+                name: 'authentication',
+                type: 'hidden',
+                default: 'body',
+            },
+        ];
+        this.test = {
+            request: {
+                baseURL: 'https://auth.atomicmail.ai',
+                url: '/api/v1/agents',
+                method: 'GET',
+            },
+        };
+    }
+}
+exports.AtomicMailOAuth2Api = AtomicMailOAuth2Api;
+//# sourceMappingURL=AtomicMailOAuth2Api.credentials.js.map

--- a/integrations/n8n/vetting/dist/nodes/AtomicMail/AtomicMail.node.js
+++ b/integrations/n8n/vetting/dist/nodes/AtomicMail/AtomicMail.node.js
@@ -5,6 +5,7 @@ const n8n_workflow_1 = require("n8n-workflow");
 const index_js_1 = require("../../vendor/agentic-core/index.js");
 const attachments_1 = require("../../lib/attachments");
 const jmap_1 = require("../../lib/jmap");
+const oauth_1 = require("../../lib/oauth");
 const session_1 = require("../../lib/session");
 const props_1 = require("../../lib/props");
 function unwrapJmapResult(context, itemIndex, result) {
@@ -34,11 +35,43 @@ class AtomicMail {
             usableAsTool: true,
             credentials: [
                 {
+                    name: 'atomicMailOAuth2Api',
+                    required: false,
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                    },
+                },
+                {
                     name: 'atomicMailApi',
                     required: false,
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
             ],
             properties: [
+                {
+                    displayName: 'Authentication',
+                    name: 'authentication',
+                    type: 'options',
+                    noDataExpression: true,
+                    options: [
+                        {
+                            name: 'API Key (Legacy)',
+                            value: 'apiKey',
+                            description: 'Agent-owned inbox via the proof-of-work path',
+                        },
+                        {
+                            name: 'OAuth2 (Recommended)',
+                            value: 'oAuth2',
+                            description: 'A person signs in once and authorizes n8n — no proof of work',
+                        },
+                    ],
+                    default: 'oAuth2',
+                    displayOptions: {
+                        hide: { resource: ['help'] },
+                    },
+                },
                 {
                     displayName: 'Resource',
                     name: 'resource',
@@ -115,12 +148,27 @@ class AtomicMail {
                     default: 'get',
                 },
                 {
+                    displayName: 'Inbox Name or ID',
+                    name: 'inbox',
+                    type: 'options',
+                    typeOptions: {
+                        loadOptionsMethod: 'getInboxes',
+                    },
+                    default: '',
+                    description: 'Which inbox to act as. Leave empty to auto-select when the connection has exactly one inbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                        hide: { resource: ['account', 'help'] },
+                    },
+                },
+                {
                     displayName: 'Account Namespace',
                     name: 'accountId',
                     type: 'string',
                     default: 'default',
                     description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes in this workflow',
                     displayOptions: {
+                        show: { authentication: ['apiKey'] },
                         hide: { resource: ['help'] },
                     },
                 },
@@ -132,6 +180,7 @@ class AtomicMail {
                     default: '',
                     description: 'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
                     displayOptions: {
+                        show: { authentication: ['apiKey'] },
                         hide: { resource: ['account', 'help'] },
                     },
                 },
@@ -302,9 +351,20 @@ class AtomicMail {
                 },
             ],
         };
+        this.methods = {
+            loadOptions: {
+                async getInboxes() {
+                    const inboxes = await (0, oauth_1.listOAuthInboxes)(this);
+                    return inboxes.map((inbox) => ({
+                        name: inbox.inboxId ? `${inbox.inboxId} (${inbox.accountId})` : inbox.accountId,
+                        value: inbox.accountId,
+                    }));
+                },
+            },
+        };
     }
     async execute() {
-        var _a, _b, _c, _d;
+        var _a, _b, _c, _d, _e;
         const items = this.getInputData();
         const returnData = [];
         for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
@@ -321,8 +381,120 @@ class AtomicMail {
                     });
                     continue;
                 }
-                const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', itemIndex));
                 const itemJson = (_a = items[itemIndex]) === null || _a === void 0 ? void 0 : _a.json;
+                const authentication = this.getNodeParameter('authentication', itemIndex, 'oAuth2');
+                if (authentication === 'oAuth2' && (await (0, oauth_1.hasOAuthCredential)(this))) {
+                    if (resource === 'account') {
+                        throw new n8n_workflow_1.NodeOperationError(this.getNode(), 'Register applies to the legacy API-key (proof-of-work) path. With OAuth the inbox is created when you connect the Atomic Mail OAuth2 credential — switch Authentication to "API Key (Legacy)" to use Register.', { itemIndex });
+                    }
+                    const oauthAccountId = await (0, oauth_1.resolveOAuthAccountId)(this, this.getNodeParameter('inbox', itemIndex, ''));
+                    const inboxContext = await (0, oauth_1.ensureOAuthInboxContext)(this, staticData, oauthAccountId);
+                    if (resource === 'inbox' && operation === 'list') {
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.listInboxBody)(inboxContext.mailboxId)));
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    if (resource === 'email' && operation === 'send') {
+                        const to = (0, props_1.requiredString)(this.getNodeParameter('to', itemIndex), 'to');
+                        const subject = (0, props_1.requiredString)(this.getNodeParameter('subject', itemIndex), 'subject');
+                        const body = (0, props_1.requiredString)(this.getNodeParameter('body', itemIndex), 'body');
+                        const binaryProperty = (0, props_1.optionalTrimmedString)(this.getNodeParameter('binaryProperty', itemIndex, ''));
+                        if (binaryProperty) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), 'Binary attachments are not yet supported on the OAuth path. Switch Authentication to "API Key (Legacy)" to send attachments.', { itemIndex });
+                        }
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.sendMailBody)({ context: inboxContext, to, subject, body })));
+                        const setError = (0, oauth_1.jmapSetErrorMessage)(result.body);
+                        if (setError) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), setError, { itemIndex });
+                        }
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    if (resource === 'email' && operation === 'reply') {
+                        const mailId = (0, props_1.requiredString)(this.getNodeParameter('mailId', itemIndex), 'mailId');
+                        const body = (0, props_1.requiredString)(this.getNodeParameter('body', itemIndex), 'body');
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.replyBody)({ context: inboxContext, mailId, body })));
+                        const setError = (0, oauth_1.jmapSetErrorMessage)(result.body);
+                        if (setError) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), setError, { itemIndex });
+                        }
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    if (resource === 'jmap' && operation === 'request') {
+                        const requestSource = this.getNodeParameter('requestSource', itemIndex, 'preset');
+                        const dryRun = this.getNodeParameter('dryRun', itemIndex, false);
+                        if (dryRun) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), 'Dry run is only supported with the API-key (legacy) credential.', { itemIndex });
+                        }
+                        const parsedVars = (0, jmap_1.parseVarsJson)(this.getNodeParameter('vars', itemIndex, ''));
+                        if (!parsedVars.ok) {
+                            throw new n8n_workflow_1.NodeOperationError(this.getNode(), parsedVars.message, { itemIndex });
+                        }
+                        let opsJson;
+                        if (requestSource === 'inline') {
+                            const opsParam = this.getNodeParameter('ops', itemIndex, '');
+                            opsJson =
+                                typeof opsParam === 'string'
+                                    ? (0, props_1.optionalTrimmedString)(opsParam)
+                                    : opsParam && typeof opsParam === 'object'
+                                        ? JSON.stringify(opsParam)
+                                        : undefined;
+                            if (!opsJson) {
+                                throw new n8n_workflow_1.NodeOperationError(this.getNode(), (0, index_js_1.sharedError)('mcp_ops_required'), {
+                                    itemIndex,
+                                });
+                            }
+                        }
+                        else {
+                            const opsFile = (0, props_1.requiredString)(this.getNodeParameter('opsFile', itemIndex, ''), 'opsFile');
+                            opsJson = await (0, index_js_1.readOpsFile)('n8n://oauth', opsFile);
+                        }
+                        const substituted = (0, oauth_1.substituteOpsVars)(opsJson, {
+                            ACCOUNT_ID: oauthAccountId,
+                            INBOX: inboxContext.address,
+                            INBOX_MAILBOX_ID: inboxContext.mailboxId,
+                            ...((_b = parsedVars.vars) !== null && _b !== void 0 ? _b : {}),
+                        });
+                        const result = unwrapJmapResult(this, itemIndex, await (0, oauth_1.jmapViaOAuth)(this, oauthAccountId, (0, oauth_1.opsJsonToBody)(substituted)));
+                        returnData.push({
+                            json: {
+                                ...(0, session_1.authPassthrough)(itemJson),
+                                ok: true,
+                                status: result.status,
+                                body: result.body,
+                            },
+                            pairedItem: { item: itemIndex },
+                        });
+                        continue;
+                    }
+                    throw new n8n_workflow_1.NodeOperationError(this.getNode(), `Unsupported operation ${resource}/${operation}.`, { itemIndex });
+                }
+                const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', itemIndex, 'default'));
                 const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
                 const inlineApiKey = this.getNodeParameter('apiKey', itemIndex, '');
                 if (resource === 'account' && operation === 'ensureRegistered') {
@@ -335,7 +507,7 @@ class AtomicMail {
                                 ...(0, session_1.authPassthrough)(itemJson),
                                 skipped: true,
                                 idempotent: true,
-                                inbox: (_c = (_b = stored === null || stored === void 0 ? void 0 : stored.inbox) !== null && _b !== void 0 ? _b : session.currentInboxId) !== null && _c !== void 0 ? _c : '',
+                                inbox: (_d = (_c = stored === null || stored === void 0 ? void 0 : stored.inbox) !== null && _c !== void 0 ? _c : session.currentInboxId) !== null && _d !== void 0 ? _d : '',
                                 accountId: accountIdResolved,
                                 ...((stored === null || stored === void 0 ? void 0 : stored.apiKey) ? { apiKey: stored.apiKey } : {}),
                             },
@@ -399,7 +571,7 @@ class AtomicMail {
                         TO: to,
                         SUBJECT: subject,
                         BODY: body,
-                        ...((_d = attachmentResult.vars) !== null && _d !== void 0 ? _d : {}),
+                        ...((_e = attachmentResult.vars) !== null && _e !== void 0 ? _e : {}),
                     };
                     const result = unwrapJmapResult(this, itemIndex, await (0, jmap_1.executePreset)(session, attachmentResult.vars
                         ? 'send_mail_blob_attachment.json'

--- a/integrations/n8n/vetting/dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js
+++ b/integrations/n8n/vetting/dist/nodes/AtomicMailTrigger/AtomicMailTrigger.node.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.AtomicMailTrigger = void 0;
 const n8n_workflow_1 = require("n8n-workflow");
 const jmap_1 = require("../../lib/jmap");
+const oauth_1 = require("../../lib/oauth");
 const session_1 = require("../../lib/session");
 const props_1 = require("../../lib/props");
 function extractEmails(body) {
@@ -50,11 +51,52 @@ class AtomicMailTrigger {
             polling: true,
             credentials: [
                 {
+                    name: 'atomicMailOAuth2Api',
+                    required: false,
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                    },
+                },
+                {
                     name: 'atomicMailApi',
                     required: false,
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
             ],
             properties: [
+                {
+                    displayName: 'Authentication',
+                    name: 'authentication',
+                    type: 'options',
+                    options: [
+                        {
+                            name: 'API Key (Legacy)',
+                            value: 'apiKey',
+                            description: 'Agent-owned inbox via the proof-of-work path',
+                        },
+                        {
+                            name: 'OAuth2 (Recommended)',
+                            value: 'oAuth2',
+                            description: 'A person signs in once and authorizes n8n — no proof of work',
+                        },
+                    ],
+                    default: 'oAuth2',
+                },
+                {
+                    displayName: 'Inbox Name or ID',
+                    name: 'inbox',
+                    type: 'options',
+                    typeOptions: {
+                        loadOptionsMethod: 'getInboxes',
+                    },
+                    default: '',
+                    description: 'Which inbox to poll. Leave empty to auto-select when the connection has exactly one inbox. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+                    displayOptions: {
+                        show: { authentication: ['oAuth2'] },
+                    },
+                },
                 {
                     displayName: 'Poll Interval (Minutes)',
                     name: 'pollIntervalMinutes',
@@ -72,6 +114,9 @@ class AtomicMailTrigger {
                     type: 'string',
                     default: 'default',
                     description: 'Leave as `default` to match **Register**, or set a unique name for multiple inboxes',
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
                 {
                     displayName: 'API Key (Optional Override)',
@@ -80,9 +125,23 @@ class AtomicMailTrigger {
                     typeOptions: { password: true },
                     default: '',
                     description: 'Paste an existing key or an expression from **Register**. Leave empty to use saved credentials or the connected credential.',
+                    displayOptions: {
+                        show: { authentication: ['apiKey'] },
+                    },
                 },
             ],
             usableAsTool: true,
+        };
+        this.methods = {
+            loadOptions: {
+                async getInboxes() {
+                    const inboxes = await (0, oauth_1.listOAuthInboxes)(this);
+                    return inboxes.map((inbox) => ({
+                        name: inbox.inboxId ? `${inbox.inboxId} (${inbox.accountId})` : inbox.accountId,
+                        value: inbox.accountId,
+                    }));
+                },
+            },
         };
     }
     async poll() {
@@ -93,43 +152,59 @@ class AtomicMailTrigger {
             lastPollMs = Date.now();
             nodeStaticData.lastPollMs = lastPollMs;
         }
-        const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId'));
-        const inlineApiKey = this.getNodeParameter('apiKey', '');
-        const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
-        try {
-            const session = await (0, session_1.resolveSessionForExecute)(credentialStaticData, accountId, credentials, inlineApiKey, true);
-            const result = await (0, jmap_1.executePreset)(session, 'list_inbox.json');
+        const authentication = this.getNodeParameter('authentication', 'oAuth2');
+        const useOAuth = authentication === 'oAuth2' && (await (0, oauth_1.hasOAuthCredential)(this));
+        let emails;
+        if (useOAuth) {
+            const accountId = await (0, oauth_1.resolveOAuthAccountId)(this, this.getNodeParameter('inbox', '')).catch((error) => {
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), error.message);
+            });
+            const inboxContext = await (0, oauth_1.ensureOAuthInboxContext)(this, credentialStaticData, accountId);
+            const result = await (0, oauth_1.jmapViaOAuth)(this, accountId, (0, oauth_1.listInboxBody)(inboxContext.mailboxId));
             if (!result.ok) {
                 throw new n8n_workflow_1.NodeOperationError(this.getNode(), result.message);
             }
-            const emails = extractEmails(result.body);
-            const newLast = emails.reduce((acc, row) => Math.max(acc, receivedMs(row.receivedAt)), lastPollMs);
-            nodeStaticData.lastPollMs = newLast;
-            const fresh = emails
-                .filter((row) => receivedMs(row.receivedAt) > lastPollMs)
-                .map((row) => ({
-                id: row.id,
-                subject: row.subject,
-                from: row.from,
-                preview: row.preview,
-                receivedAt: row.receivedAt,
-            }));
-            if (fresh.length === 0) {
-                return null;
-            }
-            return [
-                fresh.map((row) => ({
-                    json: row,
-                })),
-            ];
+            emails = extractEmails(result.body);
         }
-        catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            if ((0, props_1.optionalTrimmedString)(inlineApiKey) || (credentials === null || credentials === void 0 ? void 0 : credentials.apiKey)) {
-                throw new n8n_workflow_1.NodeOperationError(this.getNode(), message);
+        else {
+            const accountId = (0, props_1.normalizeAccountId)(this.getNodeParameter('accountId', 'default'));
+            const inlineApiKey = this.getNodeParameter('apiKey', '');
+            const credentials = (0, session_1.credentialsFromData)(await this.getCredentials('atomicMailApi').catch(() => undefined));
+            try {
+                const session = await (0, session_1.resolveSessionForExecute)(credentialStaticData, accountId, credentials, inlineApiKey, true);
+                const result = await (0, jmap_1.executePreset)(session, 'list_inbox.json');
+                if (!result.ok) {
+                    throw new n8n_workflow_1.NodeOperationError(this.getNode(), result.message);
+                }
+                emails = extractEmails(result.body);
             }
-            throw new n8n_workflow_1.NodeOperationError(this.getNode(), `${message} Connect an API key credential, paste an API key, or run **Register** first.`);
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                if ((0, props_1.optionalTrimmedString)(inlineApiKey) || (credentials === null || credentials === void 0 ? void 0 : credentials.apiKey)) {
+                    throw new n8n_workflow_1.NodeOperationError(this.getNode(), message);
+                }
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), `${message} Connect the Atomic Mail OAuth2 credential (recommended), connect an API key credential, paste an API key, or run **Register** first.`);
+            }
         }
+        const newLast = emails.reduce((acc, row) => Math.max(acc, receivedMs(row.receivedAt)), lastPollMs);
+        nodeStaticData.lastPollMs = newLast;
+        const fresh = emails
+            .filter((row) => receivedMs(row.receivedAt) > lastPollMs)
+            .map((row) => ({
+            id: row.id,
+            subject: row.subject,
+            from: row.from,
+            preview: row.preview,
+            receivedAt: row.receivedAt,
+        }));
+        if (fresh.length === 0) {
+            return null;
+        }
+        return [
+            fresh.map((row) => ({
+                json: row,
+            })),
+        ];
     }
 }
 exports.AtomicMailTrigger = AtomicMailTrigger;


### PR DESCRIPTION
> **Draft** — the migration is validated live end-to-end (see Verification). Kept as a draft pending maintainer review and the optional client-id decision in "Open items" below.

## What changed

Migrates `@atomicmail/n8n-nodes-atomicmail` (→ **0.4.0**) from the proof-of-work handshake to **OAuth 2.0** as the default auth. On n8n Cloud the PoW path broke two ways: scrypt at `POW_DIFFICULTY=10` couldn't finish inside the challenge JWT's 3-minute TTL (`400 Invalid challenge JWT: exp claim timestamp check failed`), and the ~16 MB/attempt scrypt spiked the shared workspace until it restarted (`503 Workspace offline`). No backend changes — OAuth is already live.

- **New credential `AtomicMailOAuth2Api`** (`extends: ['oAuth2Api']`): authorization code + **PKCE `S256`** (n8n `grantType: 'pkce'`), public client (no secret, token auth `none` sent in body), `authUrl`/`accessTokenUrl` → `https://auth.atomicmail.ai/oauth/{authorize,token}`, mandatory `resource=https://api.atomicmail.ai/jmap` via pre-encoded `authQueryParameters`, scope selector `mail.read` (default) / `mail.read mail.send`, credential test `GET /api/v1/agents`. **Ships a public `client_id` default** so n8n Cloud connects out of the box; self-hosted users register their own (each instance has its own callback URL).
- **Both nodes** gained an **Authentication** selector — `OAuth2 (Recommended)` (default) / `API Key (Legacy)`. On the OAuth path all JMAP goes through `this.helpers.httpRequestWithAuthentication('atomicMailOAuth2Api', …)` with the access token as bearer and the required **`X-Atomic-Account-Id`** header on every request. n8n refreshes the access token and persists the rotated refresh token itself.
- **New Inbox parameter** (trigger + action): dropdown fed by `GET /api/v1/agents` (`accountId` UUIDs); auto-selected at runtime when the connection has exactly one inbox; clear errors for zero/multiple inboxes and non-UUID values.
- **`lib/oauth.ts`** — shared helper: `jmapViaOAuth()`, inbox/mailbox-id resolution (cached in workflow static data), JMAP body builders mirroring the bundled presets (minus `accountId` in method args — pinned server-side from the header), `$VAR` substitution for raw JMAP ops, and friendly error mapping (`400` header contract, `401 invalid_token`, `403 access_denied`, `403 insufficient_scope` → "reconnect with the Read and Send scope"). Send/reply also surface JMAP `notCreated`/`notSubmitted` failures that arrive inside HTTP 200.
- **PoW path kept, behind the legacy credential only** (`lib/session.ts` untouched): the `atomicMailApi` credential, Register, inline API-key override all still work. **Backward compat:** workflows saved before this version have no `authentication` parameter and resolve to the new default — the nodes detect that no OAuth credential is connected and automatically fall back to the legacy path.
- **Vetting/Creator-Portal mirrors refreshed** — `scripts/sync-vetting-paths.mjs` now also mirrors the new OAuth2 credential (it was omitted, so the credential the package declares in `n8n.credentials` was missing from `integrations/n8n/vetting/` and repo-root `dist/`, which the Creator Portal resolves from the repo root). Ran it; the refreshed mirrors are included here.
- `package.json`: registers the new credential under `dist/`, version 0.3.23 → 0.4.0; new `CHANGELOG.md`; `docs/n8n.md` gained a **Connect with OAuth** section and marks the API key as legacy; package README updated.

### OAuth-path limitations (legacy path still covers these)

Register (inbox is created at the consent screen instead), binary attachments on Send (needs the RFC 8620 upload endpoint contract on the OAuth path), and JMAP Dry Run. Each returns a clear error pointing at the legacy credential.

## User migration

1. Create an **Atomic Mail OAuth2 API** credential. **n8n Cloud:** leave the pre-filled Client ID, pick the scope, click **Connect my account**, sign in and pick the inbox. **Self-hosted:** register your own client first (see `docs/n8n.md`).
2. On existing nodes, switch **Authentication** to OAuth2 and select the **Inbox**. Nothing else changes — operations and output shapes are identical.
3. Do nothing → workflows keep running on the legacy PoW path.

## Verification done

- `npm run lint`, `npm run build`, `tsc --noEmit` — all green (rebuilt with the vendor bundle).
- OAuth path has **zero** `/api/v1/challenge` / scrypt / session code (verified by grep + code path: the OAuth branch never touches `resolveSessionForExecute`/`createAgentSession`). Trigger polling reads via `jmapViaOAuth` (bearer), token refresh is n8n's own OAuth refresh — no PoW anywhere on the OAuth path, and no capability minting.
- **Live end-to-end test on n8n Cloud (v2.38.2) — PASSED.** Created an `OAuth2 API` credential with `grantType: pkce`, the auth/token URLs, the shipped `client_id`, `resource` query param and scope `mail.read mail.send`; the credential dialog's **OAuth Redirect URL is `https://oauth.n8n.cloud/oauth2/callback`** (confirms the shared-callback / central-proxy model our client is registered for — n8n-io/n8n#23568 does not reproduce here). Ran the flow: authorize → sign-in → consent → **token exchange succeeded → "Account connected".**
- Live check of the discovery document confirms endpoints, `S256`-only, `mail.read`/`mail.send`, token auth `none`.
- Helper unit smoke tests against the compiled `dist` (var substitution incl. `$INBOX` vs `$INBOX_MAILBOX_ID` precedence and JSON escaping, ops envelope parsing, `notCreated` detection, list body shape).

## Notes

1. **Client ID.** A public client is registered (RFC 7591 DCR, `token_endpoint_auth_method: none`, redirect `https://oauth.n8n.cloud/oauth2/callback`), baked as the credential's `clientId` default, and validated live (above). *Optional:* it is a dynamically-registered (`dyn:`) client with no RFC 7592 management token — if an official first-party `client_id` is preferred for the verified connector, swap the default before release (one-line change; nothing else depends on the value).
2. **n8n PKCE** — the generic `oAuth2Api` supports `grantType: 'pkce'` (authorization code + `S256`) since n8n 0.222.0; confirmed live on n8n Cloud 2.38.2.
3. **Vetting mirrors refreshed — required, this is a verified Creator Portal node.** `scripts/sync-vetting-paths.mjs` omitted the new OAuth2 credential (fixed here), and the repo-root `dist/` + `integrations/n8n/vetting/` mirrors were still on the pre-OAuth build — so a 0.4.0 vetting would otherwise have resolved the old PoW node without the OAuth2 credential. Both are refreshed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
