### PR TITLE
chore: bring glama.json maintainer (7supersayin) into main

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "maintainers": [
-    "dom-dalty"
+    "dom-dalty",
+    "7supersayin"
   ]
 }


### PR DESCRIPTION
Sync develop→main: only the 7supersayin maintainer entry (from #50).